### PR TITLE
[RFC] Add generic & audit log schemas

### DIFF
--- a/gordon_gcp/schemas/audit-log.schema.json
+++ b/gordon_gcp/schemas/audit-log.schema.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "id": "https://github.com/spotify/gordon-gcp/blob/master/gordon_gcp/schemas/audit-log.schema.json",
+    "title": "Google Audit Log Messages",
+    "description": "Schema for parsing Google Audit Log Messages",
+    "required": ["protoPayload", "logName"],
+    "properties": {
+        "protoPayload": {
+            "type": "object",
+            "properties": {
+                "methodName": {
+                    "type": "string",
+                    "description": "Action performed on a GCP",
+                    "enum": [
+                        "v1.compute.instances.insert",
+                        "v1.compute.instances.delete"
+                    ]
+                },
+                "resourceName": {
+                    "type": "string",
+                    "description": "",
+                    "examples": [
+                        "projects/a-project-id/zones/a-zone-name/instances/an-instance-name"
+                    ],
+                    "pattern": "^projects/[0-9]+/zones/[a-z\\-0-9]+/instances/[a-z\\-0-9]+"
+                }
+            },
+            "required": ["methodName", "resourceName"]
+        },
+        "logName": {
+            "type": "string",
+            "description": "Name of audit log",
+            "examples": [
+                "projects/a-project-id/logs/cloudaudit.googleapis.com%2Factivity"
+            ],
+            "pattern": "^projects/[a-z][a-z\\-0-9]{5,29}/logs/cloudaudit.googleapis.com%2Factivity"
+        },
+        "receiveTimestamp": {
+            "type": "string",
+            "description": "Time the log entry was received by Stackdriver Logging",
+            "examples": [
+                "2018-01-01T23:13:45.123456789Z"
+            ],
+            "pattern": "^(\\d+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.\\d+)([Zz]|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))"
+
+        },
+        "timestamp": {
+            "type": "string",
+            "description": "Time the operation status was reported",
+            "examples": [
+                "2018-01-01T23:13:45.123456789Z"
+            ],
+            "pattern": "^(\\d+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.\\d+)([Zz]|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))"
+        }
+    }
+}

--- a/gordon_gcp/schemas/event.schema.json
+++ b/gordon_gcp/schemas/event.schema.json
@@ -1,3 +1,64 @@
 {
-    "foo": "bar"
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "id": "https://github.com/spotify/gordon-gcp/blob/master/gordon_gcp/schemas/event.schema.json",
+    "title": "Generic Event Messages",
+    "description": "Schema for parsing generic event messages",
+    "required": ["action", "timestamp", "resourceRecords"],
+    "properties": {
+        "action": {
+            "description": "Add or delete resource record sets (rrdatas) listed",
+            "type": "string",
+            "enum": ["additions", "deletions"]
+        },
+        "timestamp": {
+            "type": "string",
+            "description": "Time the message was emitted",
+            "examples": [
+                "2018-01-01T23:13:45.123456789Z"
+            ],
+            "pattern": "^(\\d+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.\\d+)([Zz]|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))"
+        },
+        "resourceRecords": {
+            "description": "DNS resource records upon which to act",
+            "type": "object",
+            "required": ["name", "rrdatas", "type"],
+            "properties": {
+                "name": {
+                    "description": "Record name",
+                    "type": "string",
+                    "examples": [
+                        "www.example.com.",
+                        "some-fqdn.subdomain.example.com."
+                    ]
+                },
+                "rrdatas": {
+                    "description": "Resource record(s) that `name` point to",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "examples": [
+                        "198.1.1.50",
+                        "example.com.",
+                        "some text value"
+                    ]
+                },
+                "ttl": {
+                    "description": "TTL in seconds; default 300 seconds",
+                    "type": "number",
+                    "maximum": 86400,
+                    "minimum": 300,
+                    "default": 300
+                },
+                "type": {
+                    "description": "Type of resource record(s) as supported by Google Cloud DNS",
+                    "type": "string",
+                    "enum": ["A", "AAAA", "CNAME", "MX", "NS", "PTR", "SOA", "SRV", "TXT"]
+                }
+            }
+        }
+    }
 }

--- a/gordon_gcp/schemas/examples/audit-log.first-operation.json
+++ b/gordon_gcp/schemas/examples/audit-log.first-operation.json
@@ -1,0 +1,54 @@
+{
+  "insertId": "123456789101112",
+  "logName": "projects/some-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "first": true,
+    "id": "operation-1234-5678-9101-1121",
+    "producer": "compute.googleapis.com"
+  },
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "not-real@cloudservices.gserviceaccount.com"
+    },
+    "authorizationInfo": [
+      {
+        "granted": true,
+        "permission": "compute.instances.create"
+      }
+    ],
+    "methodName": "v1.compute.instances.insert",
+    "request": {
+      "@type": "compute.googleapis.com/compute.instances.insert"
+    },
+    "requestMetadata": {
+      "callerSuppliedUserAgent": "Managed Infrastructure Mixer Client"
+    },
+    "resourceName": "projects/123456789101/zones/us-central1-c/instances/an-instance-name-b34c",
+    "response": {
+      "@type": "compute.googleapis.com/operation",
+      "id": "234567891011121314",
+      "insertTime": "2017-12-04T12:13:44.785-08:00",
+      "name": "operation-1234-5678-9101-1121",
+      "operationType": "insert",
+      "progress": "0",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/some-project/zones/us-central1-c/operations/operation-1234-5678-9101-1121",
+      "status": "PENDING",
+      "targetId": "123456789101213141",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/some-project/zones/us-central1-c/instances/an-instance-name-b34c",
+      "zone": "https://www.googleapis.com/compute/v1/projects/some-project/zones/us-central1-c"
+    },
+    "serviceName": "compute.googleapis.com"
+  },
+  "receiveTimestamp": "2017-12-04T20:13:45.494149958Z",
+  "resource": {
+    "labels": {
+      "instance_id": "123456789101213141",
+      "project_id": "some-project",
+      "zone": "us-central1-c"
+    },
+    "type": "gce_instance"
+  },
+  "severity": "NOTICE",
+  "timestamp": "2017-12-04T20:13:44.181Z"
+}

--- a/gordon_gcp/schemas/examples/audit-log.last-operation.json
+++ b/gordon_gcp/schemas/examples/audit-log.last-operation.json
@@ -1,0 +1,30 @@
+{
+    "insertId": "123456789101112",
+    "logName": "projects/some-project/logs/cloudaudit.googleapis.com%2Factivity",
+    "operation": {
+        "id": "operation-1234-5678-9101-1121",
+        "last": true,
+        "producer": "compute.googleapis.com"
+    },
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {},
+        "methodName": "v1.compute.instances.insert",
+        "requestMetadata": {
+            "callerSuppliedUserAgent": "Managed Infrastructure Mixer Client"
+        },
+        "resourceName": "projects/123456789101/zones/us-central1-c/instances/an-instance-name-b45c",
+        "serviceName": "compute.googleapis.com"
+    },
+    "receiveTimestamp": "2017-12-04T20:13:51.414016721Z",
+    "resource": {
+        "labels": {
+            "instance_id": "123456789101213141",
+            "project_id": "some-project",
+            "zone": "us-central1-c"
+        },
+        "type": "gce_instance"
+    },
+    "severity": "NOTICE",
+    "timestamp": "2017-12-04T20:13:50.717Z"
+}

--- a/gordon_gcp/schemas/examples/audit-log.no-operation.json
+++ b/gordon_gcp/schemas/examples/audit-log.no-operation.json
@@ -1,0 +1,25 @@
+{
+    "insertId": "123456789101112",
+    "logName": "projects/a-project/logs/cloudaudit.googleapis.com%2Factivity",
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {},
+        "methodName": "v1.compute.instances.insert",
+        "requestMetadata": {
+            "callerSuppliedUserAgent": "Managed Infrastructure Mixer Client"
+        },
+        "resourceName": "projects/123456789101/zones/us-central1-c/instances/an-instance-name-a123b",
+        "serviceName": "compute.googleapis.com"
+    },
+    "receiveTimestamp": "2017-12-04T20:13:51.414016721Z",
+    "resource": {
+        "labels": {
+            "instance_id": "123456789101213141",
+            "project_id": "a-project",
+            "zone": "us-central1-c"
+        },
+        "type": "gce_instance"
+    },
+    "severity": "NOTICE",
+    "timestamp": "2017-12-04T20:13:50.717Z"
+}

--- a/gordon_gcp/schemas/examples/event.A.json
+++ b/gordon_gcp/schemas/examples/event.A.json
@@ -1,0 +1,12 @@
+{
+    "resourceRecords": {
+        "name": "lynntest-a-1234.foo.spotify.net.",
+        "rrdatas": [
+            "10.1.2.3"
+        ],
+        "ttl": 300,
+        "type": "A"
+    },
+    "timestamp": "2017-12-04T20:13:51.414016721Z",
+    "action": "additions"
+}

--- a/gordon_gcp/schemas/examples/event.CNAME.json
+++ b/gordon_gcp/schemas/examples/event.CNAME.json
@@ -1,0 +1,12 @@
+{
+    "action": "additions",
+    "timestamp": "2017-12-04T20:13:51.414016721Z",
+    "resourceRecords": {
+        "name": "lynntest-a-1234.spotify.net.",
+        "rrdatas": [
+            "lynntest-a-1234.foo.spotify.net."
+        ],
+        "ttl": 300,
+        "type": "CNAME"
+    }
+}

--- a/gordon_gcp/schemas/examples/event.NS.json
+++ b/gordon_gcp/schemas/examples/event.NS.json
@@ -1,0 +1,15 @@
+{
+    "action": "additions",
+    "timestamp": "2017-12-04T20:13:51.414016721Z",
+    "resourceRecords": {
+        "name": "gordontest.spotify.net.",
+        "rrdatas": [
+            "ns-cloud-c1.googledomains.com.",
+            "ns-cloud-c2.googledomains.com.",
+            "ns-cloud-c3.googledomains.com.",
+            "ns-cloud-c4.googledomains.com."
+        ],
+        "ttl": 21600,
+        "type": "SOA"
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,10 @@ setup(
             'gcp.pubsub = gordon_gcp.pubsub:PubSubClient',
         ],
     },
+    data_files=[
+        'schemas/audit-log.schema.json',
+        'schemas/event.schema.json'
+    ],
     classifiers=CLASSIFIERS,
     keywords=KEYWORDS,
     zip_safe=False,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

Add message schemas for validation when subscribing to Google PubSub. This ports over the GCP-related aspects of @descent3me [original PR](https://github.com/spotify/gordon/pull/4). 

Validation will happen in gordon core (PR to come).

I'm adding documentation, but I've opened this up for comments for now.

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->

N/A

**Special notes for your reviewer**:

Tests still aren't going to pass yet because of some initial assumptions made in previous PRs.

I've tested validation of the included examples with the `jsonschema` package locally:

```python
>>> import json
>>> import jsonschema
>>>
>>> with open('gordon_gcp/schemas/event.schema.json', 'r') as f:
...   event_schema = json.load(f)
>>> with open('gordon_gcp/schemas/examples/event.A.json', 'r') as f:
...   a_event_exp = json.load(f)
>>> with open('gordon_gcp/schemas/examples/event.NS.json', 'r') as f:
...   ns_event_exp = json.load(f)
>>> with open('gordon_gcp/schemas/examples/event.CNAME.json', 'r') as f:
...   cname_event_exp = json.load(f)
>>>
>>> # would throw errors if not valid
>>> jsonschema.validate(a_event_exp, event_schema)
>>> jsonschema.validate(ns_event_exp, event_schema)
>>> jsonschema.validate(cname_event_exp, event_schema)
>>>
>>> with open('gordon_gcp/schemas/audit-log.schema.json', 'r') as f:
...   audit_schema = json.load(f)
>>> with open('gordon_gcp/schemas/examples/audit-log.first-operation.json', 'r') as f:
...   first_audit_exp = json.load(f)
>>> with open('gordon_gcp/schemas/examples/audit-log.last-operation.json', 'r') as f:
...   last_audit_exp = json.load(f)
>>> with open('gordon_gcp/schemas/examples/audit-log.noop-operation.json', 'r') as f:
...   noop_audit_exp = json.load(f)
>>>
>>> jsonschema.validate(first_audit_exp, event_schema)
>>> jsonschema.validate(last_audit_exp, event_schema)
>>> jsonschema.validate(noop_audit_exp, event_schema)
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @spotify/alf 
