### PR TITLE
Implement IEventConsumer for Google Pub/Sub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==2.3.9
 google-auth==1.3.0
+google-cloud-pubsub==0.30.1
 gordon-dns==0.0.1.dev1
 jsonschema==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     entry_points={
         'gordon.plugins': [
             'gcp.enricher = gordon_gcp:GCEEnricher',
-            'gcp.event_consumer = gordon_gcp:GPSEventConsumer',
+            'gcp.event_consumer = gordon_gcp:get_event_consumer',
             'gcp.publisher = gordon_gcp:GDNSPublisher',
         ],
     },

--- a/src/gordon_gcp/exceptions.py
+++ b/src/gordon_gcp/exceptions.py
@@ -36,3 +36,7 @@ class GCPHTTPError(GCPGordonError):
 
 class GCPAuthError(GCPGordonError):
     """Authentication error with Google Cloud."""
+
+
+class GCPConfigError(GCPGordonError):
+    """Improper or incomplete configuration for plugin."""

--- a/src/gordon_gcp/plugins/__init__.py
+++ b/src/gordon_gcp/plugins/__init__.py
@@ -14,14 +14,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from gordon_gcp.plugins import event_consumer
 # Mainly for easier documentation reading
 from gordon_gcp.plugins.enricher import *  # noqa: F403
 from gordon_gcp.plugins.event_consumer import *  # noqa: F403
 from gordon_gcp.plugins.publisher import *  # noqa: F403
 
-
 __all__ = (
     enricher.__all__ +  # noqa: F405
     event_consumer.__all__ +  # noqa: F405
-    publisher.__all__  # noqa: F405
+    publisher.__all__ +  # noqa: F405
+    ('get_event_consumer',)
 )
+
+
+def get_event_consumer(config, success_channel, error_channel, **kwargs):
+    """Get a GPSEventConsumer client.
+
+    A factory function that validates configuration, creates schema
+    validator and parser clients, creates an auth and a pubsub client,
+    and returns an event consumer (:interface:`gordon.interfaces.
+    IEventConsumerClient`) provider.
+
+    Args:
+        config (dict): Google Cloud Pub/Sub-related configuration.
+        success_channel (asyncio.Queue): queue to place a successfully
+            consumed message to be further handled by the ``gordon``
+            core system.
+        error_channel (asyncio.Queue): queue to place a message met
+            with errors to be further handled by the ``gordon`` core
+            system.
+        kwargs (dict): Additional keyword arguments to pass to the
+            event consumer.
+    Returns:
+        A :class:`GPSEventConsumer` instance.
+    """
+    builder = event_consumer.GPSEventConsumerBuilder(
+        config, success_channel, error_channel, **kwargs)
+    return builder.build_event_consumer()

--- a/src/gordon_gcp/plugins/_utils.py
+++ b/src/gordon_gcp/plugins/_utils.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Common utils shared among plugins."""
+
+
+import logging
+
+
+class GEventMessageLogger(logging.LoggerAdapter):
+    def process(self, log_msg, kwargs):
+        log = f'[msg-{self.extra["msg_id"]}]: {log_msg}'
+        return log, kwargs

--- a/src/gordon_gcp/plugins/event_consumer.py
+++ b/src/gordon_gcp/plugins/event_consumer.py
@@ -31,9 +31,17 @@ work is complete.
 """
 
 import datetime
+import json
+import logging
 
 import zope.interface
+from google.cloud import pubsub  # NOQA
 from gordon import interfaces
+
+from gordon_gcp import exceptions
+from gordon_gcp.plugins import _utils
+from gordon_gcp.schema import parse  # NOQA
+from gordon_gcp.schema import validate  # NOQA
 
 
 __all__ = ('GEventMessage', 'GPSEventConsumer')
@@ -53,7 +61,7 @@ class GEventMessage:
             to ``None``.
     """
     def __init__(self, pubsub_msg, data, phase=None):
-        self.msg_id = pubsub_msg._ack_id
+        self.msg_id = pubsub_msg.message_id
         self._pubsub_msg = pubsub_msg
         self.data = data
         self.phase = phase
@@ -78,7 +86,17 @@ class GEventMessage:
 
 @zope.interface.implementer(interfaces.IEventConsumerClient)
 class GPSEventConsumer:
-    """Consume events from Google Cloud Pub/Sub.
+    """Consume messages from Google Cloud Pub/Sub.
+
+    Pub/Sub messages are continually consumed via google-cloud-python's
+    `pubsub` module using gRPC. Every consumed message will create an
+    asyncio task that handles the message schema validation, creation
+    of a :class:`GEventMessage` instance (`event_msg`), and the
+    forwarding on for further processing via the
+    :obj:`self.success_channel`. The `pubsub` module handles the message
+    ack deadline extension behind the scenes. Once the `event_msg` is
+    done processing, gordon's core routing system will submit it back to
+    this consumer to be `ack`'ed via the `cleanup` method.
 
     Args:
         config (dict): configuration relevant to Cloud Pub/Sub.
@@ -90,15 +108,121 @@ class GPSEventConsumer:
     """
     phase = 'consume'
 
-    def __init__(self, config, success_channel, error_channel):
-        self.config = config
+    def __init__(self, config, subscriber, validator, parser, success_channel,
+                 error_channel, loop, **kwargs):
         self.success_channel = success_channel
+        # NOTE: error channel not yet used, but may be in future
         self.error_channel = error_channel
+        self._subscriber = subscriber
+        self._subscription = config['subscription']
+        self._validator = validator
+        self._parser = parser
+        self._message_schemas = validator.schemas.keys()
+        self._loop = loop
+        self._logger = logging.getLogger('')
 
-    def start(self):
-        # do something
-        pass  # pragma: no cover
+    async def cleanup(self, event_msg):
+        """Ack Pub/Sub message and update event message history.
 
-    def cleanup(self):
-        # do something
-        pass  # pragma: no cover
+        Args:
+            event_msg (GEventMessage): message to clean up
+        """
+        msg_logger = _utils.GEventMessageLogger(
+            self._logger, {'msg_id': event_msg.msg_id})
+
+        msg_logger.info(f'Acking message.')
+        # "blocking" method but just puts msg on a request queue that
+        # google.cloud.pubsub manages with threads+grpc
+        event_msg._pubsub_msg.ack()
+
+        msg = 'Acknowledged message in Pub/Sub.'
+        event_msg.append_to_history(msg, self.phase)
+        msg_logger.info(f'Message is done processing.')
+
+    async def update_phase(self, event_msg, phase=None):
+        """Update event message phase to completed phase.
+
+        Updating the message's phase signals that the message has
+        completed this phase, and the gordon core router logic should
+        pass it onto the next phase (e.g. "enrich").
+
+        Args:
+            event_msg (GEventMessage): event message to update.
+            phase (str): Optional: phase to update message. Defaults to
+                "consume".
+        """
+        old_phase = event_msg.phase
+        event_msg.phase = phase or self.phase
+        msg = f'Updated phase from "{old_phase}" to "{event_msg.phase}".'
+        event_msg.append_to_history(msg, self.phase)
+
+    def _create_gevent_msg(self, pubsub_msg, data, schema):
+        log_entry = f'Created a "{schema}" message.'
+        msg = GEventMessage(pubsub_msg, data)
+        msg.append_to_history(log_entry, self.phase)
+        return msg
+
+    def _get_and_validate_pubsub_msg_schema(self, pubsub_msg_data):
+        for _schema in self._message_schemas:
+            try:
+                self._validator.validate(pubsub_msg_data, _schema)
+                return _schema
+            except exceptions.InvalidMessageError as e:
+                continue
+
+    async def _handle_pubsub_msg(self, pubsub_msg):
+        msg_id = pubsub_msg.message_id
+        msg_logger = _utils.GEventMessageLogger(
+            self._logger, {'msg_id': msg_id})
+        msg_logger.info('Received new message.')
+
+        try:
+            data = json.loads(pubsub_msg.data)
+            msg_logger.info(f'Received data: {data}')
+        except json.JSONDecodeError as e:
+            msg = ('Issue loading message data as JSON. '
+                   f'Given data: {pubsub_msg.data}')
+            msg_logger.warn(f'{msg}')
+            pubsub_msg.ack()
+            return
+
+        schema = self._get_and_validate_pubsub_msg_schema(data)
+        if schema is None:
+            msg_logger.warn('No schema found for message received, acking.')
+            pubsub_msg.ack()
+            return
+
+        msg_logger.info(f'Message is valid for "{schema}" schema.')
+
+        event_msg_data = self._parser.parse(data, schema)
+        event_msg = self._create_gevent_msg(pubsub_msg, event_msg_data, schema)
+
+        # if the message has resource records, assume it has all info
+        # it needs to be published, and therefore is already enriched
+        phase = 'enrich' if event_msg_data['resourceRecords'] else 'consume'
+        msg_logger.info(f'Updating message phase to "{phase}".')
+        await self.update_phase(event_msg, phase=phase)
+
+        msg_logger.info(f'Adding message to the success channel.')
+        await self.success_channel.put(event_msg)
+
+    def _create_handle_pubsub_msg_task(self, pubsub_msg):
+        self._loop.create_task(self._handle_pubsub_msg(pubsub_msg))
+
+    async def start(self):
+        """Start consuming messages from Google Pub/Sub.
+
+        Once a Pub/Sub message is validated, a :class:`GEventMessage`
+        is created for the message, then passed to the
+        :obj:`self.success_channel` to be handled by an IEnricher
+        plugin.
+        """
+        # TODO (lynn): look into needing flow control, e.g.:
+        # flow_control = pubsub_v1.types.FlowControl(max_messages=10)
+        # self._subscriber.subscribe(self._subscription,
+        #     flow_control=flow_control)
+
+        subscription = self._subscriber.subscribe(self._subscription)
+        # NOTE: automatically extends deadline in the background;
+        #       must `nack()` if can't finish.
+        subscription.open(self._create_handle_pubsub_msg_task)

--- a/src/gordon_gcp/plugins/event_consumer.py
+++ b/src/gordon_gcp/plugins/event_consumer.py
@@ -31,10 +31,13 @@ work is complete.
 """
 
 import asyncio
+import concurrent.futures
 import datetime
+import functools
 import json
 import logging
 import os
+import threading
 
 import zope.interface
 from google.api_core import exceptions as google_exceptions
@@ -169,9 +172,10 @@ class GPSEventConsumerBuilder:
         # Silly emulator constraints
         creds = getattr(auth_client, 'creds', None)
         client = pubsub.SubscriberClient(credentials=creds)
+
         try:
             client.create_subscription(
-                self.config['topic'], self.config['subscription'])
+                self.config['subscription'], self.config['topic'])
 
         except google_exceptions.AlreadyExists:
             # subscription already exists
@@ -188,19 +192,68 @@ class GPSEventConsumerBuilder:
             logging.error(msg, exc_info=e)
             raise exceptions.GCPGordonError(msg)
 
-        return client
+        logging.info(f'Starting a "{self.config["subscription"]}" subscriber '
+                     f'to "{self.config["topic"]}" topic.')
+        return client.subscribe(self.config['subscription'])
 
     def build_event_consumer(self):
         self._validate_config()
         validator = validate.MessageValidator()
         parser = parse.MessageParser()
         auth_client = self._init_auth()
-        subscriber = self._init_subscriber_client(auth_client)
+        subscription = self._init_subscriber_client(auth_client)
         loop = self.kwargs.get('loop', asyncio.get_event_loop())
 
         return GPSEventConsumer(
-            self.config, subscriber, validator, parser, self.success_channel,
+            self.config, subscription, validator, parser, self.success_channel,
             self.error_channel, loop)
+
+
+class _GPSThread(threading.Thread):
+    """Pub/Sub Message-specific thread with its own asyncio event loop.
+
+    .. attention::
+        This thread class is not meant to be worked with directly.
+
+    Google's Pub/Sub library is blocking. This thread class allows us
+    to create work in another thread/loop and not block the main event
+    loop within Gordon.
+
+    Inspiration directly from https://stackoverflow.com/a/29302684
+
+    Args:
+        event (threading.Event): event for thread instance to await
+            signal (via ``event.wait()``) to start work.
+        name (str): thread name
+        daemon (bool): whether the thread should be daemonized or not.
+            Defaults to ``False``.
+    """
+    def __init__(self, event, name=None, daemon=False):
+        super().__init__(name=name, daemon=daemon)
+        self.loop = None
+        self.thread_id = None
+        self.event = event
+
+    def run(self):
+        """Create and start thread's own event loop."""
+        self.loop = asyncio.new_event_loop()
+        self.thread_id = threading.current_thread()
+        self.loop.call_soon(self.event.set)
+        self.loop.run_forever()
+
+    def stop(self):
+        """Stop the thread's event loop. Thread safe."""
+        self.loop.call_soon_threadsafe(self.loop.stop)
+
+    def add_task(self, coro):
+        """Schedule a task to the thread's event loop. Thread safe.
+
+        Args:
+            coro: an asyncio `coroutine <https://docs.python.org/3/
+                library/asyncio-task.html#coroutine>`_ function
+        """
+        f = functools.partial(asyncio.ensure_future, coro, loop=self.loop)
+        self.loop.call_soon_threadsafe(f)
 
 
 @zope.interface.implementer(interfaces.IEventConsumerClient)
@@ -239,6 +292,7 @@ class GPSEventConsumer:
         self._message_schemas = validator.schemas.keys()
         self._loop = loop
         self._logger = logging.getLogger('')
+        self._threads = {}
 
     async def cleanup(self, event_msg):
         """Ack Pub/Sub message and update event message history.
@@ -249,13 +303,18 @@ class GPSEventConsumer:
         msg_logger = _utils.GEventMessageLogger(
             self._logger, {'msg_id': event_msg.msg_id})
 
-        msg_logger.info(f'Acking message.')
+        msg_logger.debug(f'Acking message.')
         # "blocking" method but just puts msg on a request queue that
         # google.cloud.pubsub manages with threads+grpc
         event_msg._pubsub_msg.ack()
 
         msg = 'Acknowledged message in Pub/Sub.'
         event_msg.append_to_history(msg, self.phase)
+
+        event, thread = self._threads[event_msg._pubsub_msg.message_id]
+        event.set()
+        thread.stop()
+
         msg_logger.info(f'Message is done processing.')
 
     async def update_phase(self, event_msg, phase=None):
@@ -297,7 +356,7 @@ class GPSEventConsumer:
 
         try:
             data = json.loads(pubsub_msg.data)
-            msg_logger.info(f'Received data: {data}')
+            msg_logger.debug(f'Received data: {data}')
         except json.JSONDecodeError as e:
             msg = ('Issue loading message data as JSON. '
                    f'Given data: {pubsub_msg.data}')
@@ -311,22 +370,55 @@ class GPSEventConsumer:
             pubsub_msg.ack()
             return
 
-        msg_logger.info(f'Message is valid for "{schema}" schema.')
+        msg_logger.debug(f'Message is valid for "{schema}" schema.')
 
         event_msg_data = self._parser.parse(data, schema)
-        event_msg = self._create_gevent_msg(pubsub_msg, event_msg_data, schema)
+        event_msg = self._create_gevent_msg(
+            pubsub_msg, event_msg_data, schema)
 
         # if the message has resource records, assume it has all info
         # it needs to be published, and therefore is already enriched
         phase = 'enrich' if event_msg_data['resourceRecords'] else 'consume'
-        msg_logger.info(f'Updating message phase to "{phase}".')
+        msg_logger.debug(f'Updating message phase to "{phase}".')
         await self.update_phase(event_msg, phase=phase)
 
-        msg_logger.info(f'Adding message to the success channel.')
+        msg_logger.debug(f'Adding message to the success channel.')
         await self.success_channel.put(event_msg)
 
-    def _create_handle_pubsub_msg_task(self, pubsub_msg):
-        self._loop.create_task(self._handle_pubsub_msg(pubsub_msg))
+    def _thread_pubsub_msg(self, pubsub_msg):
+        # Create a new thread with its own event loop to process the
+        # pubsub message.
+        event = threading.Event()
+        thread_name = f'GPSThread_msg-id_{pubsub_msg.message_id}'
+        thread = _GPSThread(event, name=thread_name, daemon=True)
+        thread.start()
+        # Block signal to the thread before start accepting tasks
+        # Let the loop's signal us, rather than sleeping
+        event.wait()
+        thread.add_task(self._handle_pubsub_msg(pubsub_msg))
+
+        # save thread to stop/clean up during self.cleanup
+        self._threads[pubsub_msg.message_id] = (event, thread)
+
+    def _manage_subs(self):
+        # TODO (lynn): look into needing flow control, e.g.:
+        # flow_control = pubsub_v1.types.FlowControl(max_messages=10)
+        # self._subscriber.subscribe(self._subscription,
+        #     flow_control=flow_control)
+        # NOTE: automatically extends deadline in the background;
+        #       must `nack()` if can't finish. We don't proactively
+        #       `nack` in this plugin since it'll just get redelivered.
+        #       A dead process will also timeout the message, with which
+        #       it will redeliver.
+        future = self._subscriber.open(self._thread_pubsub_msg)
+
+        try:
+            # we're running in a threadpool because this is blocking
+            future.result()
+        except Exception as e:
+            self._subscriber.close()
+            logging.error(f'Issue polling subscription: {e}', exc_info=e)
+            raise exceptions.GCPGordonError(e)
 
     async def start(self):
         """Start consuming messages from Google Pub/Sub.
@@ -336,12 +428,13 @@ class GPSEventConsumer:
         :obj:`self.success_channel` to be handled by an IEnricher
         plugin.
         """
-        # TODO (lynn): look into needing flow control, e.g.:
-        # flow_control = pubsub_v1.types.FlowControl(max_messages=10)
-        # self._subscriber.subscribe(self._subscription,
-        #     flow_control=flow_control)
-
-        subscription = self._subscriber.subscribe(self._subscription)
-        # NOTE: automatically extends deadline in the background;
-        #       must `nack()` if can't finish.
-        subscription.open(self._create_handle_pubsub_msg_task)
+        main_loop = asyncio.get_event_loop()
+        # so many threads, name this so it's identifiable
+        pfx = 'ThreadPoolExecutor-GPSEventConsumer'
+        # NOTE: there should only be one thread pool executor worker
+        #       from here since this method is only called once from
+        #       gordon core, so there _should_ be no need to limit
+        #       workers
+        executor = concurrent.futures.ThreadPoolExecutor(thread_name_prefix=pfx)
+        coro = main_loop.run_in_executor(executor, self._manage_subs)
+        await asyncio.gather(coro, loop=main_loop, return_exceptions=True)

--- a/src/gordon_gcp/schema/validate.py
+++ b/src/gordon_gcp/schema/validate.py
@@ -94,7 +94,7 @@ class MessageValidator:
             try:
                 with open(schema_file, 'r') as f:
                     schemas[schema_name] = json.load(f)
-                    logging.info(f'Successfully loaded schema "{schema_name}"')
+                    logging.info(f'Successfully loaded schema "{schema_name}".')
 
             except (FileNotFoundError, json.JSONDecodeError) as e:
                 msg = f'Error loading schema "{schema_name}": {e}.'

--- a/tests/unit/clients/test_http.py
+++ b/tests/unit/clients/test_http.py
@@ -16,6 +16,7 @@
 
 import datetime
 import json
+from unittest import mock
 
 import aiohttp
 import pytest
@@ -79,8 +80,6 @@ params = [
 async def test_set_valid_token(token, expiry, exp_mocked_refresh, client,
                                monkeypatch):
     """Refresh tokens if invalid or not set."""
-    datetime.datetime = conftest.MockDatetime
-
     mock_refresh_token_called = 0
 
     async def mock_refresh_token():
@@ -93,7 +92,10 @@ async def test_set_valid_token(token, expiry, exp_mocked_refresh, client,
     monkeypatch.setattr(
         client._auth_client, 'refresh_token', mock_refresh_token)
 
-    await client.set_valid_token()
+    patch = 'gordon_gcp.clients.http.datetime.datetime'
+    with mock.patch(patch, conftest.MockDatetime):
+        await client.set_valid_token()
+
     assert exp_mocked_refresh == mock_refresh_token_called
 
 

--- a/tests/unit/plugins/test_event_consumer.py
+++ b/tests/unit/plugins/test_event_consumer.py
@@ -16,27 +16,49 @@
 
 import asyncio
 import datetime
+import functools
 import json
 
 import pytest
+from google.cloud import pubsub
 from google.cloud import pubsub_v1
 from gordon import interfaces
 
+from gordon_gcp import exceptions
 from gordon_gcp.plugins import event_consumer
+from gordon_gcp.schema import parse
+from gordon_gcp.schema import validate
 
 
 #####
 # GEventMessage tests
 #####
-@pytest.fixture
-def raw_msg_data():
-    return {'some': 'data'}
+@pytest.fixture(scope='session')
+def audit_log_data():
+    resource_name = ('projects/123456789101/zones/us-central1-c/instances/'
+                     'an-instance-name-b34c')
+    return {
+        'action': 'additions',
+        'resourceName': resource_name,
+        'timestamp': '2017-12-04T20:13:51.414016721Z'
+    }
+
+
+@pytest.fixture(scope='session')
+def raw_msg_data(audit_log_data):
+    return {
+        'protoPayload': {
+            'methodName': 'v1.compute.instances.insert',
+            'resourceName': audit_log_data['resourceName'],
+        },
+        'timestamp': '2017-12-04T20:13:51.414016721Z',
+    }
 
 
 @pytest.fixture
 def pubsub_msg(mocker, raw_msg_data):
     pubsub_msg = mocker.MagicMock(pubsub_v1.subscriber.message.Message)
-    pubsub_msg._ack_id = 1234
+    pubsub_msg.message_id = 1234
     pubsub_msg.data = bytes(json.dumps(raw_msg_data), encoding='utf-8')
     return pubsub_msg
 
@@ -44,13 +66,14 @@ def pubsub_msg(mocker, raw_msg_data):
 @pytest.mark.parametrize('phase', [None, 'emo'])
 def test_implements_message_interface(phase, pubsub_msg, raw_msg_data):
     """GEventMessage implements IEventMessage."""
+    args = [pubsub_msg, raw_msg_data]
     if phase:
-        msg = event_consumer.GEventMessage(pubsub_msg, raw_msg_data, phase)
-    else:
-        msg = event_consumer.GEventMessage(pubsub_msg, raw_msg_data)
+        args.append(phase)
+
+    msg = event_consumer.GEventMessage(*args)
 
     assert pubsub_msg is msg._pubsub_msg
-    assert pubsub_msg._ack_id is msg.msg_id
+    assert pubsub_msg.message_id is msg.msg_id
     assert raw_msg_data == msg.data
     assert not msg.history_log
     assert phase == msg.phase
@@ -63,20 +86,27 @@ class MockDatetime(datetime.datetime):
         return datetime.datetime(2018, 1, 1, 11, 30, 0)
 
 
+def patch_datetime(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        datetime.datetime = MockDatetime
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@patch_datetime
 def test_event_msg_append_to_history(pubsub_msg, raw_msg_data):
     """Write entry to event message history log."""
-    datetime.datetime = MockDatetime
-
     msg = event_consumer.GEventMessage(pubsub_msg, raw_msg_data)
-
     entry_msg = 'an entry'
     plugin = 'test-plugin'
+    msg.append_to_history(entry_msg, plugin)
+
     expected = [{
         'timestamp': '2018-01-01T11:30:00.000000Z',
         'plugin': plugin,
         'message': entry_msg
     }]
-    msg.append_to_history(entry_msg, plugin)
 
     assert expected == msg.history_log
 
@@ -84,16 +114,244 @@ def test_event_msg_append_to_history(pubsub_msg, raw_msg_data):
 #####
 # GPSEventConsumer tests
 #####
-def test_implements_consumer_interface():
-    """GPSEventConsumer implements IEventConsumerClient."""
-    config = {'foo': 'bar'}
+@pytest.fixture
+def parser(mocker, monkeypatch, raw_msg_data):
+    mock = mocker.MagicMock(parse.MessageParser)
+    data = {
+        'action': 'additions',
+        'resourceName': raw_msg_data['protoPayload']['resourceName'],
+        'resourceRecords': None,
+    }
+    mock.parse.return_value = data
+    patch = 'gordon_gcp.plugins.event_consumer.parse.MessageParser'
+    monkeypatch.setattr(patch, mock)
+    return mock
+
+
+@pytest.fixture
+def validator(mocker, monkeypatch):
+    mock = mocker.MagicMock(validate.MessageValidator)
+    schemas = {'schema1': 'a-schema', 'schema2': 'another-schema'}
+    mock.schemas = schemas
+    patch = 'gordon_gcp.plugins.event_consumer.validate.MessageValidator'
+    monkeypatch.setattr(patch, mock)
+    return mock
+
+
+@pytest.fixture
+def subscriber_client(mocker, monkeypatch):
+    mock = mocker.MagicMock(pubsub.SubscriberClient)
+    patch = 'gordon_gcp.plugins.event_consumer.pubsub.SubscriberClient'
+    monkeypatch.setattr(patch, mock)
+    return mock
+
+
+def test_event_consumer_default(subscriber_client, validator, parser,
+                                event_loop):
+    """GPSEventConsumer implements IEventConsumerClient"""
+    config = {'subscription': '/projects/test-project/subscriptions/test-sub'}
     success, error = asyncio.Queue(), asyncio.Queue()
-    client = event_consumer.GPSEventConsumer(config, success, error)
+    client = event_consumer.GPSEventConsumer(
+        config, subscriber_client, validator, parser, success, error,
+        event_loop)
 
     assert interfaces.IEventConsumerClient.providedBy(client)
     assert interfaces.IEventConsumerClient.implementedBy(
         event_consumer.GPSEventConsumer)
-    assert config is client.config
+    assert subscriber_client is client._subscriber
+    assert config['subscription'] is client._subscription
+    assert validator is client._validator
+    assert ['schema1', 'schema2'] == list(client._message_schemas)
     assert success is client.success_channel
     assert error is client.error_channel
     assert 'consume' == client.phase
+    assert event_loop is client._loop
+
+
+@pytest.fixture
+def consumer(subscriber_client, validator, event_loop):
+    config = {'subscription': '/projects/test-project/subscriptions/test-sub'}
+    success, error = asyncio.Queue(), asyncio.Queue()
+    parser = parse.MessageParser()
+    client = event_consumer.GPSEventConsumer(
+        config, subscriber_client, validator, parser, success, error,
+        event_loop)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_start(consumer):
+    """Consumer starts consuming from a Pub/Sub subscription."""
+    await consumer.start()
+
+    sub = '/projects/test-project/subscriptions/test-sub'
+    consumer._subscriber.subscribe.assert_called_once_with(sub)
+    consumer._subscriber.subscribe.return_value.open.assert_called_once_with(
+        consumer._create_handle_pubsub_msg_task)
+
+
+@pytest.mark.asyncio
+async def test_create_handle_pubsub_msg_task(consumer, event_loop):
+    """Create an asyncio task for handling a pubsub message."""
+    consumer._create_handle_pubsub_msg_task({})
+
+    tasks = asyncio.Task.all_tasks(loop=event_loop)
+    # one of the tasks is the actual test itself running in
+    # pytest-asyncio's event_loop; the test needs to be ran in the
+    # event_loop, so it can await the task created by
+    # _create_handle_pubsub_msg_task
+    assert 2 == len(tasks)
+    names = [t._coro.__name__ for t in tasks]
+    assert '_handle_pubsub_msg' in names
+
+
+@pytest.fixture
+def mock_get_and_validate(consumer, mocker, monkeypatch):
+    mock = mocker.MagicMock(return_value='audit-log')
+    monkeypatch.setattr(consumer, '_get_and_validate_pubsub_msg_schema', mock)
+    return mock
+
+
+@pytest.fixture
+def mock_create_gevent_msg(consumer, mocker, monkeypatch):
+    mock = mocker.MagicMock()
+    monkeypatch.setattr(consumer, '_create_gevent_msg', mock)
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_handle_pubsub_msg(mocker, monkeypatch, consumer, raw_msg_data,
+                                 audit_log_data, caplog, pubsub_msg,
+                                 mock_get_and_validate, mock_create_gevent_msg):
+    """Validate pubsub msg, create GEventMessage, and add to success chnl."""
+    event_msg = event_consumer.GEventMessage(pubsub_msg, audit_log_data, [])
+    mock_create_gevent_msg.return_value = event_msg
+
+    await consumer._handle_pubsub_msg(pubsub_msg)
+
+    audit_log_data.update({'resourceRecords': []})
+    mock_get_and_validate.assert_called_once_with(raw_msg_data)
+    mock_create_gevent_msg.assert_called_once_with(
+        pubsub_msg, audit_log_data, 'audit-log')
+    assert 1 == consumer.success_channel.qsize()
+    assert event_msg is await consumer.success_channel.get()
+    assert 5 == len(caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_pubsub_msg_json_err(mocker, monkeypatch, consumer, caplog,
+                                          pubsub_msg, mock_get_and_validate,
+                                          mock_create_gevent_msg):
+    """Ack an invalidate JSON pubsub msg."""
+    pubsub_msg.data = bytes('invalid json', encoding='utf-8')
+
+    await consumer._handle_pubsub_msg(pubsub_msg)
+
+    pubsub_msg.ack.assert_called_once_with()
+    mock_get_and_validate.assert_not_called()
+    mock_create_gevent_msg.assert_not_called()
+    assert 0 == consumer.success_channel.qsize()
+    assert 2 == len(caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_pubsub_msg_invalid(mocker, monkeypatch, consumer, caplog,
+                                         pubsub_msg,
+                                         mock_get_and_validate,
+                                         mock_create_gevent_msg):
+    """Ack an invalidate pubsub msg."""
+    consumer._get_and_validate_pubsub_msg_schema.return_value = None
+
+    await consumer._handle_pubsub_msg(pubsub_msg)
+
+    pubsub_msg.ack.assert_called_once_with()
+    mock_create_gevent_msg.assert_not_called()
+    assert 0 == consumer.success_channel.qsize()
+    assert 3 == len(caplog.records)
+
+
+@patch_datetime
+def test_create_gevent_msg(pubsub_msg, raw_msg_data, validator):
+    """Create an instance of GEventMessage with a pubsub message."""
+    config = {'subscription': 'foo'}
+    # bare bones consumer
+    consumer = event_consumer.GPSEventConsumer(
+        config, None, validator, None, None, None, None)
+
+    msg = consumer._create_gevent_msg(pubsub_msg, raw_msg_data, 'a-schema')
+
+    assert isinstance(msg, event_consumer.GEventMessage)
+
+    exp_entry = {
+        'timestamp': '2018-01-01T11:30:00.000000Z',
+        'plugin': 'consume',
+        'message': 'Created a "a-schema" message.',
+    }
+    assert exp_entry in msg.history_log
+
+
+@pytest.mark.parametrize('side_effect, expected', [
+    # schema1 is valid
+    ((True, exceptions.InvalidMessageError()), 'schema1'),
+    # schema2 is valid
+    ((exceptions.InvalidMessageError(), True), 'schema2'),
+    # no valid schemas
+    ((exceptions.InvalidMessageError(), exceptions.InvalidMessageError()),
+     None),
+])
+def test_get_and_validate_pubsub_msg_schema(mocker, pubsub_msg, validator,
+                                            side_effect, expected):
+    """Validate & return schema of a pubsub message's data."""
+    config = {'subscription': 'foo'}
+    parser = parse.MessageParser()
+    consumer = event_consumer.GPSEventConsumer(
+        config, None, validator, parser, None, None, None)
+
+    validator.validate.side_effect = side_effect
+    data = json.loads(pubsub_msg.data)
+    schema = consumer._get_and_validate_pubsub_msg_schema(data)
+
+    calls = [mocker.call(data, 'schema1')]
+    if not side_effect[0]:
+        calls.append(mocker.call(data, 'schema2'))
+    validator.validate.assert_has_calls(calls)
+
+    assert expected == schema
+
+
+@patch_datetime
+@pytest.mark.asyncio
+@pytest.mark.parametrize('init_phase', (None, 'emo'))
+async def test_update_phase(init_phase, mocker, consumer, pubsub_msg):
+    """Phase of a GEventMessage instance is updated."""
+    event_msg = event_consumer.GEventMessage(pubsub_msg, {}, phase=init_phase)
+
+    assert init_phase == event_msg.phase  # sanity check
+    await consumer.update_phase(event_msg)
+
+    assert 'consume' == event_msg.phase
+    exp_entry = {
+        'timestamp': '2018-01-01T11:30:00.000000Z',
+        'plugin': 'consume',
+        'message': f'Updated phase from "{init_phase}" to "consume".',
+    }
+    assert exp_entry in event_msg.history_log
+
+
+@patch_datetime
+@pytest.mark.asyncio
+async def test_cleanup(mocker, consumer, caplog, pubsub_msg):
+    """Consumer acks Pub/Sub message."""
+    event_msg = event_consumer.GEventMessage(pubsub_msg, {})
+
+    await consumer.cleanup(event_msg)
+
+    pubsub_msg.ack.assert_called_once_with()
+
+    exp_entry = {
+        'timestamp': '2018-01-01T11:30:00.000000Z',
+        'plugin': 'consume',
+        'message': 'Acknowledged message in Pub/Sub.',
+    }
+    assert exp_entry in event_msg.history_log
+    assert 2 == len(caplog.records)

--- a/tests/unit/plugins/test_event_consumer.py
+++ b/tests/unit/plugins/test_event_consumer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017 Spotify AB
+# Copyright 2017-2018 Spotify AB
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,15 +15,77 @@
 # limitations under the License.
 
 import asyncio
+import datetime
+import json
 
-import pytest  # NOQA
+import pytest
+from google.cloud import pubsub_v1
 from gordon import interfaces
 
 from gordon_gcp.plugins import event_consumer
 
 
-def test_implements_interface():
-    """GPSEventConsumer implements IEventConsumerClient"""
+#####
+# GEventMessage tests
+#####
+@pytest.fixture
+def raw_msg_data():
+    return {'some': 'data'}
+
+
+@pytest.fixture
+def pubsub_msg(mocker, raw_msg_data):
+    pubsub_msg = mocker.MagicMock(pubsub_v1.subscriber.message.Message)
+    pubsub_msg._ack_id = 1234
+    pubsub_msg.data = bytes(json.dumps(raw_msg_data), encoding='utf-8')
+    return pubsub_msg
+
+
+@pytest.mark.parametrize('phase', [None, 'emo'])
+def test_implements_message_interface(phase, pubsub_msg, raw_msg_data):
+    """GEventMessage implements IEventMessage."""
+    if phase:
+        msg = event_consumer.GEventMessage(pubsub_msg, raw_msg_data, phase)
+    else:
+        msg = event_consumer.GEventMessage(pubsub_msg, raw_msg_data)
+
+    assert pubsub_msg is msg._pubsub_msg
+    assert pubsub_msg._ack_id is msg.msg_id
+    assert raw_msg_data == msg.data
+    assert not msg.history_log
+    assert phase == msg.phase
+
+
+# pytest prevents monkeypatching datetime directly
+class MockDatetime(datetime.datetime):
+    @classmethod
+    def utcnow(cls):
+        return datetime.datetime(2018, 1, 1, 11, 30, 0)
+
+
+def test_event_msg_append_to_history(pubsub_msg, raw_msg_data):
+    """Write entry to event message history log."""
+    datetime.datetime = MockDatetime
+
+    msg = event_consumer.GEventMessage(pubsub_msg, raw_msg_data)
+
+    entry_msg = 'an entry'
+    plugin = 'test-plugin'
+    expected = [{
+        'timestamp': '2018-01-01T11:30:00.000000Z',
+        'plugin': plugin,
+        'message': entry_msg
+    }]
+    msg.append_to_history(entry_msg, plugin)
+
+    assert expected == msg.history_log
+
+
+#####
+# GPSEventConsumer tests
+#####
+def test_implements_consumer_interface():
+    """GPSEventConsumer implements IEventConsumerClient."""
     config = {'foo': 'bar'}
     success, error = asyncio.Queue(), asyncio.Queue()
     client = event_consumer.GPSEventConsumer(config, success, error)

--- a/tests/unit/plugins/test_init.py
+++ b/tests/unit/plugins/test_init.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+
+import aiohttp
+import pytest
+from google.api_core import exceptions as google_exceptions
+from google.cloud import pubsub
+from google.cloud.pubsub_v1.subscriber.policy import thread
+
+from gordon_gcp import exceptions
+from gordon_gcp import plugins
+from gordon_gcp.clients import auth
+
+
+API_BASE_URL = 'https://example.com'
+API_URL = f'{API_BASE_URL}/v1/foo_endpoint'
+
+
+@pytest.fixture(scope='session')
+def fake_keyfile_data():
+    return {
+        'type': 'service_account',
+        'project_id': 'a-test-project',
+        'private_key_id': 'yeahright',
+        'private_key': 'nope',
+        'client_email': 'test-key@a-test-project.iam.gserviceaccount.com',
+        'client_id': '12345678910',
+        'auth_uri': f'{API_BASE_URL}/auth',
+        'token_uri': f'{API_BASE_URL}/token',
+        'auth_provider_x509_cert_url': f'{API_BASE_URL}/certs',
+        'client_x509_cert_url': f'{API_BASE_URL}/x509/a-test-project'
+    }
+
+
+@pytest.fixture
+def fake_keyfile(fake_keyfile_data, tmpdir):
+    tmp_keyfile = tmpdir.mkdir('keys').join('fake_keyfile.json')
+    tmp_keyfile.write(json.dumps(fake_keyfile_data))
+    return tmp_keyfile
+
+
+@pytest.fixture
+def config(fake_keyfile):
+    return {
+        'keyfile': fake_keyfile,
+        'project': 'test-example',
+        'topic': 'a-topic',
+        'subscription': 'a-subscription'
+    }
+
+
+@pytest.fixture
+async def auth_client(mocker, monkeypatch):
+    mock = mocker.Mock(auth.GAuthClient)
+    mock.token = '0ldc0ffe3'
+    mock._session = aiohttp.ClientSession()
+    creds = mocker.Mock()
+    mock.creds = creds
+    monkeypatch.setattr(
+        'gordon_gcp.plugins.event_consumer.auth.GAuthClient', mock)
+    yield mock
+    await mock._session.close()
+
+
+@pytest.fixture
+def subscriber_client(mocker, monkeypatch):
+    mock = mocker.Mock(pubsub.SubscriberClient)
+    # what is actually returned from client.create_subscription
+    mock_sub = mocker.Mock(thread.Policy)
+    mock.return_value.create_subscription.return_value = mock_sub
+    patch = 'gordon_gcp.plugins.event_consumer.pubsub.SubscriberClient'
+    monkeypatch.setattr(patch, mock)
+    return mock
+
+
+@pytest.fixture
+def emulator(monkeypatch):
+    monkeypatch.delenv('PUBSUB_EMULATOR_HOST', raising=False)
+
+
+@pytest.fixture
+def exp_topic(config):
+    topic = config['topic'].split('/')[-1]
+    return f'projects/{config["project"]}/topics/{topic}'
+
+
+@pytest.fixture
+def exp_sub(config):
+    subscription = config['subscription'].split('/')[-1]
+    return f'projects/{config["project"]}/subscriptions/{subscription}'
+
+
+@pytest.mark.parametrize('local,provide_loop,topic,sub', [
+    (True, True, 'a-topic',
+     'projects/test-example/subscriptions/a-subscription'),
+    (False, False, 'projects/test-example/topics/a-topic', 'a-subscription'),
+])
+def test_get_event_consumer(local, provide_loop, topic, sub, config, exp_topic,
+                            auth_client, exp_sub, subscriber_client, emulator,
+                            monkeypatch, event_loop):
+    """Happy path to initialize a Publisher client."""
+    success_chnl, error_chnl = asyncio.Queue(), asyncio.Queue()
+
+    if local:
+        monkeypatch.setenv('PUBSUB_EMULATOR_HOST', True)
+
+    config['topic'], config['subscription'] = topic, sub
+    kwargs = {
+        'config': config,
+        'success_channel': success_chnl,
+        'error_channel': error_chnl,
+    }
+    if provide_loop:
+        kwargs['loop'] = event_loop
+    client = plugins.get_event_consumer(**kwargs)
+
+    creds = None
+    if not local:
+        creds = auth_client.return_value.creds
+    subscriber_client.assert_called_once_with(credentials=creds)
+    sub_inst = subscriber_client.return_value
+    sub_inst.create_subscription.assert_called_once_with(exp_topic, exp_sub)
+
+    assert client._validator
+    assert client._parser
+    assert client.success_channel is success_chnl
+    assert client.error_channel is error_chnl
+
+    assert client._subscriber
+    assert exp_sub == client._subscription
+
+    assert ['audit-log', 'event'] == sorted(client._message_schemas)
+
+    if provide_loop:
+        assert event_loop is client._loop
+    else:
+        assert event_loop is not client._loop
+
+
+@pytest.mark.parametrize('config_key,exp_msg',  [
+    ('keyfile', 'The path to a Service Account JSON keyfile is required '),
+    ('project', 'The GCP project where Cloud Pub/Sub is located is required.'),
+    ('topic', ('A topic for the client to subscribe to in Cloud Pub/Sub is '
+               'required.')),
+    ('subscription', ('A subscription for the client to pull messages from in '
+                      'Cloud Pub/Sub is required.')),
+])
+def test_get_event_consumer_config_raises(config_key, exp_msg, config,
+                                          auth_client, subscriber_client,
+                                          caplog, emulator):
+    """Raise with improper configuration."""
+    success_chnl, error_chnl = asyncio.Queue(), asyncio.Queue()
+
+    config.pop(config_key)
+
+    with pytest.raises(exceptions.GCPConfigError) as e:
+        client = plugins.get_event_consumer(config, success_chnl, error_chnl)
+        client._subscriber.create_subscription.assert_not_called()
+
+    e.match('Invalid configuration:\n' + exp_msg)
+    assert 1 == len(caplog.records)
+
+
+def test_get_event_consumer_raises_topic(config, auth_client, subscriber_client,
+                                         caplog, emulator, exp_topic, exp_sub):
+    """Raise when there is no topic to subscribe to."""
+    success_chnl, error_chnl = asyncio.Queue(), asyncio.Queue()
+
+    exp = google_exceptions.NotFound('foo')
+    sub_inst = subscriber_client.return_value
+    sub_inst.create_subscription.side_effect = [exp]
+
+    with pytest.raises(exceptions.GCPGordonError) as e:
+        plugins.get_event_consumer(config, success_chnl, error_chnl)
+        sub_inst.create_subscription.assert_called_once_with(exp_topic, exp_sub)
+
+    e.match(f'Topic "{exp_topic}" does not exist.')
+    assert 3 == len(caplog.records)
+
+
+def test_get_event_consumer_raises(config, auth_client, subscriber_client,
+                                   caplog, emulator, exp_topic, exp_sub):
+    """Raise when any other error occured with creating a subscription."""
+    success_chnl, error_chnl = asyncio.Queue(), asyncio.Queue()
+
+    exp = google_exceptions.BadRequest('foo')
+    sub_inst = subscriber_client.return_value
+    sub_inst.create_subscription.side_effect = [exp]
+
+    with pytest.raises(exceptions.GCPGordonError) as e:
+        plugins.get_event_consumer(config, success_chnl, error_chnl)
+        sub_inst.create_subscription.assert_called_once_with(exp_topic, exp_sub)
+
+    e.match(f'Error trying to create subscription "{exp_sub}"')
+    assert 3 == len(caplog.records)
+
+
+def test_get_event_consumer_sub_exists(config, auth_client, subscriber_client,
+                                       emulator, exp_topic, exp_sub):
+    """Do not raise if topic already exists."""
+    success_chnl, error_chnl = asyncio.Queue(), asyncio.Queue()
+
+    exp = google_exceptions.AlreadyExists('foo')
+    sub_inst = subscriber_client.return_value
+    sub_inst.create_subscription.side_effect = [exp]
+
+    client = plugins.get_event_consumer(config, success_chnl, error_chnl)
+
+    assert client._subscriber
+
+    sub_inst.create_subscription.assert_called_once_with(exp_topic, exp_sub)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

Let's start consuming messages!

The consumer will pull a message from Google Pub/Sub (via google-cloud-python's grpc-enabled pub/sub package) and call a function to create an async task (I got inspired by [this approach](https://github.com/cloudfind/google-pubsub-asyncio/blob/master/app.py) since it's essentially mixing sync + async methods), then validate, parse, create an GEventMessage, the put that message on the success_channel queue for gordon to route it to the next plugin.


**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->

N/A

**Special notes for your reviewer**:

Note that this is an RFC: while I am pretty sure this will work, I want to spend a little time testing against the pub/sub emulator. It'll eventually be made into a system test, but that will come later. But I'd appreciate any comments on approach or whatever else as I'm testing overall functionality.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add implementation of IEventConsumer.
```
