### PR TITLE
Fix http client token refreshing logic

### DIFF
--- a/src/gordon_gcp/clients/auth.py
+++ b/src/gordon_gcp/clients/auth.py
@@ -41,10 +41,10 @@ To use:
     >>> auth_client = google_gcp.GAuthClient(keyfile=keyfile)
     # with Application Default Credentials
     >>> auth_client = google_gcp.GAuthClient()
-    >>> auth_clientcreds.token is None
+    >>> auth_client.token is None
     True
     >>> loop.run_until_complete(auth_client.refresh_token())
-    >>> auth_client.creds.token
+    >>> auth_client.token
     'c0ffe3'
 
 """

--- a/src/gordon_gcp/clients/http.py
+++ b/src/gordon_gcp/clients/http.py
@@ -73,11 +73,11 @@ class AIOConnection:
         """Check for validity of token, and refresh if none or expired."""
         is_valid = False
 
-        if self._auth_client.creds.token:
+        if self._auth_client.token:
             # Account for a token near expiration
             now = datetime.datetime.utcnow()
             skew = datetime.timedelta(seconds=60)
-            if self._auth_client.creds.expiry > (now + skew):
+            if self._auth_client.expiry > (now + skew):
                 is_valid = True
 
         if not is_valid:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
This PR fixes a bug where the http client refreshes the auth token on every request sent to a Google API because `self._auth_client.creds.token` is _always_ None. This is related to this old fix: https://github.com/spotify/gordon-janitor-gcp/pull/10/files

**Which issue(s) this PR fixes** 
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

@spotify/alf 
