### PR TITLE
Add builder class + entrypoint func for GDNSPublisher

### DIFF
--- a/docs/config-janitor.rst
+++ b/docs/config-janitor.rst
@@ -1,5 +1,5 @@
-Configuration
-=============
+Janitor Configuration
+=====================
 
 Configuring Google Cloud Platform :doc:`plugins` for the `gordon-janitor`_ service.
 

--- a/docs/config-service.rst
+++ b/docs/config-service.rst
@@ -1,5 +1,5 @@
-Configuration
-=============
+Service Configuration
+=====================
 
 Configuring Google Cloud Platform :doc:`plugins` for the `gordon`_ service.
 

--- a/docs/config-service.rst
+++ b/docs/config-service.rst
@@ -48,22 +48,64 @@ Plugin Configuration
 ``[gcp.event_consumer]``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-All configuration options above in the general ``[gcp]`` may be used here. There are no specific Google Pub/Sub Consumer-related configuration options.
+All configuration options above in the general ``[gcp]`` may be used here. Additional Google Pub/Sub Consumer-related configuration options are:
 
+.. option:: topic="STR"
+
+    `Required`: A topic to which the Event Consumer client must subscribe.
+
+    For more information on Google Pub/Sub topics, please see `Google's docs on managing topics <topics>`_.
+
+.. option:: subscription="STR"
+
+    `Required`: A subscription to the ``topic`` from which the Event Consumer client will pull.
+
+    For more information on Google Pub/Sub subscriptions, please see `Google's docs on managing subscriptions <subscriptions>`_.
 
 ``[gcp.enricher]``
 ~~~~~~~~~~~~~~~~~~
 
-All configuration options above in the general ``[gcp]`` may be used here. There are no specific Google Compute Engine Enricher-related configuration options.
+All configuration options above in the general ``[gcp]`` may be used here. Additional Google Compute Engine configuration options are:
+
+
+.. option:: dns_zone="STR"
+
+    `Required`: DNS zone to validate the correctness of A records before publishing. Must be a fully-qualified domain name (FQDN), ending in ``.``, e.g. ``example.com.``.
 
 
 ``[gcp.publisher]``
 ~~~~~~~~~~~~~~~~~~~
 
-All configuration options above in the general ``[gcp]`` may be used here. There are no specific Google DNS Publisher-related configuration options.
+All configuration options above in the general ``[gcp]`` may be used here. Additional Google Cloud DNS configuration options are:
 
+.. describe:: dns_zone="STR"
+
+    `Required`: DNS zone to validate the correctness of A records before publishing. Must be a fully-qualified domain name (FQDN), ending in ``.``, e.g. ``example.com.``.
+
+.. option:: managed_zone="STR"
+
+    `Required`: The managed zone name in Google Cloud DNS where records are to be published.
+
+    To learn more about managed zones, please see `Google's docs on managed zones <managed_zones>`_.
+
+.. option:: default_ttl=INT
+
+    `Required`: The default TTL in seconds. This will be used if the publisher receives a record set to be published that does not yet have the TTL set. Must be greater than 4.
+
+.. option:: publish_wait_timeout=INT|FLOAT
+
+    `Optional`: Timeout in seconds for waiting for confirmation that changes have been successfully completed within Google Cloud DNS. Default is 60 seconds.
+
+.. option:: api_version="STR"
+
+    `Optional`: API version for both the `changes`_ endpoint and the `resource records`_ endpoint.
 
 
 .. _`gordon`: https://github.com/spotify/gordon
 .. _`keyfiles`: https://cloud.google.com/iam/docs/creating-managing-service-account-keys
 .. _`projects`: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+.. _`topics`: https://cloud.google.com/pubsub/docs/admin#managing_topics
+.. _`subscriptions`: https://cloud.google.com/pubsub/docs/admin#managing_subscriptions
+.. _`managed_zones`: https://cloud.google.com/dns/zones/
+.. _`changes`: https://cloud.google.com/dns/api/v1/changes
+.. _`resource records`: https://cloud.google.com/dns/api/v1/resourceRecordSets/list

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -7,16 +7,20 @@ handlers = ["syslog"]
 # Plugin Config
 [gcp]
 project = "my-gcp-project"
-dns_zone = "example.com."
-managed_zone = "example-zone"
 
 [gcp.enricher]
 keyfile = "/path/to/keyfiles/compute.json"
+dns_zone = "example.com."
 
 [gcp.event_consumer]
 keyfile = "/path/to/keyfiles/pubsub.json"
+topic = "my-dns-changes"
+subscription = "gordon-consumer"
 
 [gcp.publisher]
 project = "my-dns-project"
 keyfile = "/path/to/keyfiles/dns.json"
 publish_wait_timeout = 10
+default_ttl = 300
+dns_zone = "example.com."
+managed_zone = "example-zone"

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
         'gordon.plugins': [
             'gcp.enricher = gordon_gcp:get_enricher',
             'gcp.event_consumer = gordon_gcp:get_event_consumer',
-            'gcp.publisher = gordon_gcp:GDNSPublisher',
+            'gcp.publisher = gordon_gcp:get_gdns_publisher',
         ],
         'gordon_janitor.plugins': [
             'gcp.gce = gordon_gcp:get_authority',

--- a/src/gordon_gcp/plugins/service/__init__.py
+++ b/src/gordon_gcp/plugins/service/__init__.py
@@ -16,17 +16,18 @@
 
 from gordon_gcp.plugins.service import enricher
 from gordon_gcp.plugins.service import event_consumer
+from gordon_gcp.plugins.service import gdns_publisher
 # Mainly for easier documentation reading
-from gordon_gcp.plugins.service.enricher import *  # noqa: F403
-from gordon_gcp.plugins.service.event_consumer import *  # noqa: F403
-from gordon_gcp.plugins.service.gdns_publisher import *  # noqa: F403
+from gordon_gcp.plugins.service.enricher import *  # noqa: F401,F403
+from gordon_gcp.plugins.service.event_consumer import *  # noqa: F401,F403
+from gordon_gcp.plugins.service.gdns_publisher import *  # noqa: F401,F403
 
 
 __all__ = (
     enricher.__all__ +  # noqa: F405
     event_consumer.__all__ +  # noqa: F405
     gdns_publisher.__all__ +  # noqa: F405
-    ('get_event_consumer', 'get_enricher')
+    ('get_event_consumer', 'get_enricher', 'get_gdns_publisher')
 )
 
 
@@ -79,3 +80,28 @@ def get_enricher(config, success_channel, error_channel, **kwargs):
     builder = enricher.GCEEnricherBuilder(
         config, success_channel, error_channel, **kwargs)
     return builder.build_enricher()
+
+
+def get_gdns_publisher(config, success_channel, error_channel, **kwargs):
+    """Get a GDNSPublisher client.
+
+    A factory function that validates configuration and returns a
+    publisher client (:interface:`gordon.interfaces.IPublisherClient`)
+    provider.
+
+    Args:
+        config (dict): Google Cloud DNS API related configuration.
+        success_channel (asyncio.Queue): Queue to place a successfully
+            published message to be further handled by the ``gordon``
+            core system.
+        error_channel (asyncio.Queue): Queue to place a message met
+            with errors to be further handled by the ``gordon`` core
+            system.
+        kwargs (dict): Additional keyword arguments to pass to the
+            publisher.
+    Returns:
+        A :class:`GDNSPublisher` instance.
+    """
+    builder = gdns_publisher.GDNSPublisherBuilder(
+        config, success_channel, error_channel, **kwargs)
+    return builder.build_publisher()

--- a/tests/unit/plugins/service/test_init.py
+++ b/tests/unit/plugins/service/test_init.py
@@ -252,3 +252,104 @@ def test_get_enricher_config_bad_dns_zone(mocker, caplog, enricher_config,
     exc_msg = 'A dns zone must be an FQDN and end with the root zone \("."\).'
     e.match('Invalid configuration:\n' + exc_msg)
     assert 1 == len(caplog.records)
+
+
+@pytest.fixture
+def publisher_config(fake_keyfile):
+    return {
+        'keyfile': fake_keyfile,
+        'dns_zone': 'example.com.',
+        'project': 'test-example',
+        'managed_zone': 'my-zone',
+        'default_ttl': 300,
+    }
+
+
+@pytest.mark.parametrize('conf_key,conf_value,expected', (
+    # publish_wait_timeout explicitly set
+    ('publish_wait_timeout', 30, 30),
+    # publish_wait_timeout not set
+    ('publish_wait_timeout', False, 60),
+    # api_version explicitly set
+    ('api_version', 'v1beta', 'v1beta'),
+    # # version not set
+    ('api_version', False, 'v1'),
+))
+def test_get_gdns_publisher(conf_key, conf_value, expected, mocker,
+                            publisher_config, auth_client):
+    """Happy path to initialize a GDNSPublisher client."""
+    patch = 'gordon_gcp.plugins.service.gdns_publisher.http.AIOConnection'
+    mocker.patch(patch)
+
+    if conf_value:
+        publisher_config[conf_key] = conf_value
+
+    success_chnl, error_chnl = asyncio.Queue(), asyncio.Queue()
+
+    client = service.get_gdns_publisher(
+        publisher_config, success_chnl, error_chnl)
+
+    assert isinstance(client, service.gdns_publisher.GDNSPublisher)
+    assert publisher_config == client.config
+    assert expected == getattr(client, conf_key)
+    assert success_chnl == client.success_channel
+    assert error_chnl == client.error_channel
+
+
+@pytest.mark.parametrize('conf_keys,exp_msg_snip', (
+    (('keyfile',), ('The path to a Service Account JSON keyfile is required '
+                    'to authenticate for Google Cloud DNS.')),
+    (('project',), 'The GCP project where Cloud DNS is located is required.'),
+    (('dns_zone',), 'A dns zone is required to build correct A records.'),
+    (('managed_zone',), ('A managed zone is required to publish records to '
+                         'Google Cloud DNS.')),
+    (('default_ttl',), ('A default TTL in seconds must be set for publishing '
+                        'records to Google Cloud DNS.')),
+    (('keyfile', 'project'), ('The path to a Service Account JSON keyfile is '
+                              'required to authenticate for Google Cloud DNS.\n'
+                              'The GCP project where Cloud DNS is located is '
+                              'required.\n'))
+))
+def test_get_gdns_publisher_raises(conf_keys, exp_msg_snip,
+                                   publisher_config, mocker, auth_client,
+                                   caplog):
+    """Raise when required config key(s) missing."""
+    patch = 'gordon_gcp.plugins.service.gdns_publisher.http.AIOConnection'
+    mocker.patch(patch)
+
+    for conf_key in conf_keys:
+        publisher_config.pop(conf_key)
+    success_chnl, error_chnl = asyncio.Queue(), asyncio.Queue()
+
+    with pytest.raises(exceptions.GCPConfigError) as e:
+        service.get_gdns_publisher(publisher_config, success_chnl, error_chnl)
+
+    e.match('Invalid configuration:\n' + exp_msg_snip)
+    assert len(conf_keys) == len(caplog.records)
+
+
+@pytest.mark.parametrize('conf_key,bad_value,exp_msg_snip', (
+    ('dns_zone', 'example.com', ('A dns zone must be an FQDN and end with the '
+                                 'root zone \("."\).')),
+    ('publish_wait_timeout', 'foo', ('"publish_wait_timeout" must be a '
+                                     'positive number.')),
+    ('publish_wait_timeout', -1, ('"publish_wait_timeout" must be a positive '
+                                  'number.')),
+    ('default_ttl', 'foo', '"default_ttl" must be an integer.'),
+    ('default_ttl', -1, '"default_ttl" must be greater than 4'),
+))
+def test_get_gdns_publisher_bad_config(conf_key, bad_value, exp_msg_snip,
+                                       publisher_config, mocker, auth_client,
+                                       caplog):
+    """Raise when config values are malformed."""
+    patch = 'gordon_gcp.plugins.service.gdns_publisher.http.AIOConnection'
+    mocker.patch(patch)
+
+    publisher_config[conf_key] = bad_value
+    success_chnl, error_chnl = asyncio.Queue(), asyncio.Queue()
+
+    with pytest.raises(exceptions.GCPConfigError) as e:
+        service.get_gdns_publisher(publisher_config, success_chnl, error_chnl)
+
+    e.match('Invalid configuration:\n' + exp_msg_snip)
+    assert 1 == len(caplog.records)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

As it stands, core will pass in only the config and channels to each plugin. But the `GDNSPublisher` is expecting an HTTP client as well. It also does not gracefully handle required config keys like all other plugins (and cause unhandled `KeyErrors`).

This PR adds a builder class to validate config, create the auth+http clients, and instantiates a `GDNSPublisher`. In keeping with the API design/abstraction layers, this also adds the helper function for the `setup.py` entrypoint.

I've also updated the docs on configuration to reflect required config keys (for all plugins).

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix failure for core to instantiate GDNSPublisher plugin.
```

@spotify/alf 
