### PR TITLE
Extract rrsets properly and set params as optional parameter when calling http.get_all

### DIFF
--- a/src/gordon_gcp/clients/http.py
+++ b/src/gordon_gcp/clients/http.py
@@ -184,16 +184,18 @@ class AIOConnection:
         response = await self.request(method='get', url=url, **kwargs)
         return json_callback(response)
 
-    async def get_all(self, url, params):
+    async def get_all(self, url, params=None):
         """Aggregate data from all pages of an API query.
 
         Args:
             url (str): Google API endpoint URL.
-            params (dict): URL query parameters.
+            params (dict): (optional) URL query parameters.
 
         Returns:
             list: Parsed JSON query response results.
         """
+        if not params:
+            params = {}
         items = []
         next_page_token = None
 

--- a/src/gordon_gcp/plugins/service/gdns_publisher.py
+++ b/src/gordon_gcp/plugins/service/gdns_publisher.py
@@ -245,16 +245,15 @@ class GDNSPublisher:
         Returns:
             dict containing original additions plus deletions.
         """
-        resp = await self.http_client.get_all(resource_records_url)
-        rrsets = resp['rrsets']
-
         record_name = changes['additions'][0]['name']
         record_type = changes['additions'][0]['type']
 
-        for rec in rrsets:
-            if rec['name'] == record_name and rec['type'] == record_type:
-                changes['deletions'] = [rec]
-                break
+        response = await self.http_client.get_all(resource_records_url)
+        for resp in response:
+            for rec in resp['rrsets']:
+                if rec['name'] == record_name and rec['type'] == record_type:
+                    changes['deletions'] = [rec]
+                    break
 
         return changes
 

--- a/tests/unit/clients/test_http.py
+++ b/tests/unit/clients/test_http.py
@@ -339,12 +339,18 @@ async def test_post_json_raises(client, monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('max_pages', [1, 2])
-async def test_get_all(mocker, max_pages):
+@pytest.mark.parametrize('max_pages,test_param', [
+        [1, None],
+        [2, {'test': 'param'}]
+    ]
+    )
+async def test_get_all(mocker, max_pages, test_param):
     number_of_calls = 0
 
     class TestClient(http.AIOConnection):
         async def get_json(self, url, params=None):
+            if test_param is None:
+                assert params == {}
             nonlocal number_of_calls
             if number_of_calls < (max_pages - 1):
                 number_of_calls += 1
@@ -357,5 +363,5 @@ async def test_get_all(mocker, max_pages):
     simple_paging_client = TestClient(auth_client)
 
     results = await simple_paging_client.get_all(
-        conftest.API_BASE_URL, {})
+        conftest.API_BASE_URL, params=test_param)
     assert max_pages == len(results)

--- a/tests/unit/plugins/service/test_gdns_publisher.py
+++ b/tests/unit/plugins/service/test_gdns_publisher.py
@@ -196,7 +196,7 @@ def handled_conflict_changes_done():
 
 @pytest.fixture
 def all_existing_zone_records():
-    return {
+    return [{
         'kind': 'dns#resourceRecordSetsListResponse',
         'rrsets': [
             {
@@ -210,6 +210,10 @@ def all_existing_zone_records():
                     '1 21600 3600 259200 300'
                 ]
             },
+        ]},
+        {
+        'kind': 'dns#resourceRecordSetsListResponse',
+        'rrsets': [
             {
                 'kind': 'dns#resourceRecordSet',
                 'name': 'service.example.com.',
@@ -217,16 +221,16 @@ def all_existing_zone_records():
                 'ttl': 3600,
                 'rrdatas': ['127.0.0.1']
             }
-        ]
-    }
+        ]},
+    ]
 
 
 @pytest.fixture
 def all_existing_zone_records_empty():
-    return {
+    return [{
         'kind': 'dns#resourceRecordSetsListResponse',
         'rrsets': []
-    }
+    }]
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
This PR addresses to runtime issues, where we were not properly extracting `rrsets` from the Google Cloud DNS rrset endpoint. The other addresses an issue where `http.get_all` expects there to always be `params` dict passed in.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Extract response rrsets properly
Make params optional when calling http.get_all
```

@spotify/alf 