### PR TITLE
Remove the GPThread instance once done

### DIFF
--- a/src/gordon_gcp/plugins/service/event_consumer.py
+++ b/src/gordon_gcp/plugins/service/event_consumer.py
@@ -327,9 +327,13 @@ class GPSEventConsumer:
         msg = 'Acknowledged message in Pub/Sub.'
         event_msg.append_to_history(msg, self.phase)
 
-        event, thread = self._threads[event_msg._pubsub_msg.message_id]
+        event, thread = self._threads.pop(event_msg._pubsub_msg.message_id)
         event.set()
         thread.stop()
+
+        # sanity check for GC
+        del event
+        del thread
 
         msg_logger.info(f'Message is done processing.')
 

--- a/tests/unit/plugins/service/test_event_consumer.py
+++ b/tests/unit/plugins/service/test_event_consumer.py
@@ -380,6 +380,7 @@ async def test_handle_message(mocker, consumer, caplog, pubsub_msg):
     mock_event.set.assert_called_once_with()
     mock_thread.stop.assert_called_once_with()
     assert 2 == len(caplog.records)
+    assert not consumer._threads.get(event_msg.msg_id)
 
 
 #####


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

Since we didn't ever remove `GPThread` instances from the `GEventConsumer` dict, threads were never released/gc'ed (we think), causing an every-growing amount of open file descriptors. 

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Clean up GPThread instances once done.
```

@spotify/alf 