### PR TITLE
Add kind attribute to GCPResourceRecordSet

### DIFF
--- a/src/gordon_gcp/clients/gdns.py
+++ b/src/gordon_gcp/clients/gdns.py
@@ -61,6 +61,8 @@ class GCPResourceRecordSet:
 
     Args:
         name (str): Name/label.
+        kind (str): ID for what kind of GCP resource this is. For example
+            'dns#resourceRecordSet'
         type (str): Record type (see `Google's supported records
             <https://cloud.google.com/dns/overview#supported_dns_record_
             types>`_ for valid types).
@@ -73,6 +75,7 @@ class GCPResourceRecordSet:
     #   between all of gordon* packages. It will also make use of attrs
     #   ability to optionally validate upon creation.
     name = attr.ib(type=str)
+    kind = attr.ib(type=str)
     type = attr.ib(type=str)
     rrdatas = attr.ib(type=list)
     ttl = attr.ib(type=int, default=300)
@@ -119,7 +122,8 @@ class GDNSClient(http.AIOConnection):
 
         # to limit the amount of data across the wire; also makes it
         # easier to create GCPResourceRecordSet instances
-        fields = 'rrsets/name,rrsets/rrdatas,rrsets/type,rrsets/ttl'
+        fields = ('rrsets/name,rrsets/kind,rrsets/rrdatas,'
+                  'rrsets/type,rrsets/ttl')
         params = {
             'fields': fields,
         }

--- a/tests/unit/clients/test_gdns.py
+++ b/tests/unit/clients/test_gdns.py
@@ -34,7 +34,8 @@ def test_create_gcp_rrset():
         'name': 'test',
         'type': 'A',
         'rrdatas': ['10.1.2.3'],
-        'ttl': 500
+        'ttl': 500,
+        'kind': 'dns#resourceRecordSet'
     }
     rrset = gdns.GCPResourceRecordSet(**data)
     assert data == attr.asdict(rrset)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -44,14 +44,16 @@ def fake_response_data():
                 'ttl': 300,
                 'rrdatas': [
                     '10.1.2.3',
-                ]
+                ],
+                'kind': 'dns#resourceRecordSet'
             }, {
                 'name': 'b-test.example.net.',
                 'type': 'CNAME',
                 'ttl': 600,
                 'rrdatas': [
                     'a-test.example.net.',
-                ]
+                ],
+                'kind': 'dns#resourceRecordSet'
             }, {
                 'name': 'c-test.example.net.',
                 'type': 'TXT',
@@ -59,7 +61,8 @@ def fake_response_data():
                 'rrdatas': [
                     '"OHAI"',
                     '"OYE"',
-                ]
+                ],
+                'kind': 'dns#resourceRecordSet'
             }
         ]
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
This adds a `kind` attribute to `gcp.GCPResourceRecordSet`. This is part of the RRset that returned by the Google Cloud DNS resourceRecordSets API https://cloud.google.com/dns/api/v1/resourceRecordSets#resource

A type error is currently raised without this attribute.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note

```
@spotify/alf 