### PR TITLE
Add populating of 'resourceRecords' for GEventMessages that have the 'deletions' action

### DIFF
--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -7,10 +7,11 @@ handlers = ["syslog"]
 # Plugin Config
 [gcp]
 project = "my-gcp-project"
+dns_zone = "example.com."
+managed_zone = "example-com"
 
 [gcp.enricher]
 keyfile = "/path/to/keyfiles/compute.json"
-dns_zone = "example.com."
 
 [gcp.event_consumer]
 keyfile = "/path/to/keyfiles/pubsub.json"
@@ -23,5 +24,3 @@ project = "my-dns-project"
 keyfile = "/path/to/keyfiles/dns.json"
 publish_wait_timeout = 10
 default_ttl = 300
-dns_zone = "example.com."
-managed_zone = "example-zone"

--- a/src/gordon_gcp/plugins/service/enricher.py
+++ b/src/gordon_gcp/plugins/service/enricher.py
@@ -266,6 +266,7 @@ class GCEEnricher:
             instance_resource_url = event_message.data['resourceName']
             records = await self._get_matching_records_for_deletion(
                 instance_resource_url)
+
         msg_logger.debug(f'Enriched with resource record(s): {records}')
         event_message.data['resourceRecords'].extend(records)
         msg = (f"Enriched msg with {len(event_message.data['resourceRecords'])}"

--- a/src/gordon_gcp/plugins/service/enricher.py
+++ b/src/gordon_gcp/plugins/service/enricher.py
@@ -80,6 +80,22 @@ class GCEEnricherBuilder:
             self.config['retries'] = 5
         return []
 
+    def _validate_managed_zone(self):
+        msg = []
+        if not self.config.get('managed_zone'):
+            msg.append('The name of the Google Cloud DNS managed zone is '
+                       'required to correctly delete A records for deleted '
+                       'instances.')
+        return msg
+
+    def _validate_project(self):
+        msg = []
+        if not self.config.get('project'):
+            msg.append('The GCP project that contains the Google Cloud DNS '
+                       'managed zone is required to correctly delete A records '
+                       'for deleted instances.')
+        return msg
+
     def _call_validators(self):
         """Actually run all the validations.
 
@@ -90,6 +106,8 @@ class GCEEnricherBuilder:
         msg.extend(self._validate_keyfile())
         msg.extend(self._validate_dns_zone())
         msg.extend(self._validate_retries())
+        msg.extend(self._validate_project())
+        msg.extend(self._validate_managed_zone())
         return msg
 
     def _validate_config(self):
@@ -126,6 +144,8 @@ class GCEEnricher:
             the GCE API.
     """
     phase = 'enrich'
+    RESOURCE_RECORDS_ENDPOINT = ('https://www.googleapis.com/dns/v1/projects/'
+                                 '{project}/managedZones/{managedZone}/rrsets')
 
     def __init__(self, config, metrics, http_client, **kwargs):
         self.config = config
@@ -195,6 +215,26 @@ class GCEEnricher:
                 fqdn, external_ip, default_ttl, msg_logger)
         ]
 
+    async def _get_matching_records(self, instance_resource_url):
+        # Get the fqdn of the instance
+        instance_name = instance_resource_url.split('/')[-1]
+        fqdn = self._get_fqdn(instance_name)
+
+        # Get all Google DNS records for the managed zone
+        project = self.config['project']
+        managed_zone = self.config['managed_zone']
+        resource_records_url = GCEEnricher.RESOURCE_RECORDS_ENDPOINT.format(
+            project=project, managedZone=managed_zone)
+        response = await self._http_client.get_all(resource_records_url)
+
+        # Get the Google DNS A records with name matching the instance fqdn
+        matching_records = []
+        for resp in response:
+            for rec in resp['rrsets']:
+                if rec['name'] == fqdn:
+                    matching_records.append(rec)
+        return matching_records
+
     async def handle_message(self, event_message):
         """
         Enrich message with extra context and send it to the publisher.
@@ -208,7 +248,6 @@ class GCEEnricher:
             event_message (.GEventMessage): message requiring
                 additional information.
         """
-
         # if the message has resource records, assume it has all info
         # it needs to be published, and therefore is already enriched
         if event_message.data['resourceRecords']:
@@ -219,14 +258,16 @@ class GCEEnricher:
         msg_logger = _utils.GEventMessageLogger(
             self._logger, {'msg_id': event_message.msg_id})
 
-        instance_data = await self._poll_for_instance_data(
-            event_message.data['resourceName'], msg_logger)
-        records = await self._create_rrecords(
-            event_message.data, instance_data, msg_logger)
-
+        if event_message.data['action'] == 'additions':
+            instance_data = await self._poll_for_instance_data(
+                event_message.data['resourceName'], msg_logger)
+            records = await self._create_rrecords(
+                event_message.data, instance_data, msg_logger)
+        elif event_message.data['action'] == 'deletions':
+            instance_resource_url = event_message.data['resourceName']
+            records = await self._get_matching_records(instance_resource_url)
         msg_logger.debug(f'Enriched with resource record(s): {records}')
         event_message.data['resourceRecords'].extend(records)
-
-        added_records = event_message.data['resourceRecords']
-        msg = f'Enriched msg with {len(added_records)} resource record(s).'
+        msg = (f"Enriched msg with {len(event_message.data['resourceRecords'])}"
+               " resource record(s).")
         event_message.append_to_history(msg, self.phase)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -172,6 +172,31 @@ def additions_gevent_msg(mocker, creation_audit_log_data):
         pubsub_msg, fake_data)
 
 
+@pytest.fixture(scope='session')
+def deletion_audit_log_data():
+    resource_name = ('projects/123456789101/zones/us-central1-c/instances/'
+                     'an-instance-name-abc1')
+    return {
+        'action': 'deletions',
+        'resourceName': resource_name,
+        'timestamp': '2017-12-04T20:13:51.414016722Z'
+    }
+
+
+@pytest.fixture
+def deletions_gevent_msg(mocker, deletion_audit_log_data):
+    fake_data = {
+            'action': deletion_audit_log_data['action'],
+            'resourceName': deletion_audit_log_data['resourceName'],
+            'resourceRecords': [],
+            'timestamp': deletion_audit_log_data['timestamp']
+        }
+    pubsub_msg = mocker.Mock()
+    pubsub_msg._ack_id = '1:2'
+    return event_consumer.GEventMessage(
+        pubsub_msg, fake_data)
+
+
 @pytest.fixture
 def channel_pair():
     return asyncio.Queue(), asyncio.Queue()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -148,7 +148,7 @@ def create_mock_coro(mocker):
 
 
 @pytest.fixture(scope='session')
-def audit_log_data():
+def creation_audit_log_data():
     resource_name = ('projects/123456789101/zones/us-central1-c/instances/'
                      'an-instance-name-b34c')
     return {
@@ -159,12 +159,12 @@ def audit_log_data():
 
 
 @pytest.fixture
-def gevent_msg(mocker, audit_log_data):
+def additions_gevent_msg(mocker, creation_audit_log_data):
     fake_data = {
-            'action': audit_log_data['action'],
-            'resourceName': audit_log_data['resourceName'],
+            'action': creation_audit_log_data['action'],
+            'resourceName': creation_audit_log_data['resourceName'],
             'resourceRecords': [],
-            'timestamp': audit_log_data['timestamp']
+            'timestamp': creation_audit_log_data['timestamp']
         }
     pubsub_msg = mocker.Mock()
     pubsub_msg._ack_id = '1:1'

--- a/tests/unit/plugins/service/test_event_consumer.py
+++ b/tests/unit/plugins/service/test_event_consumer.py
@@ -39,11 +39,11 @@ NEW_EV_PATCH = f'{MOD_PATCH}.asyncio.new_event_loop'
 # GEventMessage tests
 #####
 @pytest.fixture(scope='session')
-def raw_msg_data(audit_log_data):
+def raw_msg_data(creation_audit_log_data):
     return {
         'protoPayload': {
             'methodName': 'v1.compute.instances.insert',
-            'resourceName': audit_log_data['resourceName'],
+            'resourceName': creation_audit_log_data['resourceName'],
         },
         'timestamp': '2017-12-04T20:13:51.414016721Z',
     }
@@ -295,11 +295,11 @@ def mock_create_gevent_msg(consumer, mocker, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_handle_pubsub_msg(mocker, monkeypatch, consumer, raw_msg_data,
-                                 audit_log_data, caplog, pubsub_msg,
+                                 creation_audit_log_data, caplog, pubsub_msg,
                                  mock_get_and_validate, mock_create_gevent_msg):
     """Validate pubsub msg, create GEventMessage, and add to success chnl."""
     event_msg = event_consumer.GEventMessage(
-        pubsub_msg, audit_log_data, phase='consume')
+        pubsub_msg, creation_audit_log_data, phase='consume')
     mock_create_gevent_msg.return_value = event_msg
 
     mock_run_coro_threadsafe = mocker.Mock()
@@ -309,10 +309,10 @@ async def test_handle_pubsub_msg(mocker, monkeypatch, consumer, raw_msg_data,
 
     await consumer._handle_pubsub_msg(pubsub_msg)
 
-    audit_log_data.update({'resourceRecords': []})
+    creation_audit_log_data.update({'resourceRecords': []})
     mock_get_and_validate.assert_called_once_with(raw_msg_data)
     mock_create_gevent_msg.assert_called_once_with(
-        pubsub_msg, audit_log_data, 'audit-log')
+        pubsub_msg, creation_audit_log_data, 'audit-log')
 
     assert 4 == len(caplog.records)
     assert 'consume' == event_msg.phase

--- a/tests/unit/plugins/service/test_gdns_publisher.py
+++ b/tests/unit/plugins/service/test_gdns_publisher.py
@@ -91,6 +91,12 @@ def event_msg_data_with_invalid_zone(event_msg_data):
 
 
 @pytest.fixture
+def event_msg_data_with_no_resource_records(event_msg_data):
+    event_msg_data['resourceRecords'] = []
+    return event_msg_data
+
+
+@pytest.fixture
 def initial_changes_req():
     return {
         'kind': 'dns#change',
@@ -415,6 +421,19 @@ conflict_types = [
     (all_existing_zone_records(), handled_conflict_changes_req()),
     (all_existing_zone_records_empty(), initial_changes_req())
 ]
+
+
+@pytest.mark.asyncio
+async def test_handle_message_no_resource_records(
+        gdns_publisher_instance, event_message,
+        event_msg_data_with_no_resource_records, caplog):
+    """Ensure message with no resource records is logged"""
+    event_message.data = event_msg_data_with_no_resource_records
+
+    await gdns_publisher_instance.handle_message(event_message)
+    assert "Publisher received new message." in caplog.text
+    assert ('No records published or deleted as no resource records were'
+            ' present' in caplog.text)
 
 
 @pytest.mark.parametrize('existing,output', conflict_types)

--- a/tests/unit/plugins/service/test_init.py
+++ b/tests/unit/plugins/service/test_init.py
@@ -193,7 +193,12 @@ def test_get_event_consumer_sub_exists(consumer_config, auth_client,
 #####
 @pytest.fixture
 def enricher_config(fake_keyfile):
-    return {'keyfile': fake_keyfile, 'dns_zone': 'example.com.'}
+    return {
+        'keyfile': fake_keyfile,
+        'dns_zone': 'example.com.',
+        'managed_zone': 'example-com',
+        'project': 'gcp-proj-dns',
+    }
 
 
 @pytest.mark.parametrize('conf_retries,retries', [
@@ -216,7 +221,13 @@ def test_get_enricher(mocker, enricher_config, auth_client, conf_retries,
 @pytest.mark.parametrize('config_key,exc_msg', [
     ('keyfile', 'The path to a Service Account JSON keyfile is required to '
                 'authenticate to the GCE API.'),
-    ('dns_zone', 'A dns zone is required to build correct A records.')])
+    ('dns_zone', 'A dns zone is required to build correct A records.'),
+    ('managed_zone', 'The name of the Google Cloud DNS managed zone is '
+                     'required to correctly delete A records for deleted '
+                     'instances'),
+    ('project', 'The GCP project that contains the Google Cloud DNS managed '
+                'zone is required to correctly delete A records for deleted '
+                'instances.')])
 def test_get_enricher_missing_config_raises(mocker, caplog, enricher_config,
                                             auth_client, config_key, exc_msg,
                                             metrics):


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now, when parsing audit log pub/sub messages, the consumer sets the `resourceRecords` of the GEventMessage to an empty list, and the enricher assumes any that this empty`resourceRecords` needs to be enriched. However, that doesn't necessarily work for `deletions` actions, as when the enricher tries to find the related instance information from the GCP Instances API, the instance is already gone/deleted and will hence 404. 

This PR adds the ability to populate the `resourceRecords` for GEventMessages that have the 'deletions' action via querying the Google Cloud DNS API for the records that Gordon initially created for the GCE host. Currently, this would only be the A record.

**Special notes for your reviewer**:

The `name` and `type` parameters for the Google DNS API List endpoint are used to and only get the results/records that Gordon initially created for the GCE host (currently only the A record).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Add populating of 'resourceRecords' for GEventMessages that have the 'deletions' action
```
