### PR TITLE
Fix TZ-aware/naive mismatch in consumer

### DIFF
--- a/src/gordon_gcp/plugins/service/event_consumer.py
+++ b/src/gordon_gcp/plugins/service/event_consumer.py
@@ -313,8 +313,8 @@ class GPSEventConsumer:
         msg_logger.info('Received new message.')
 
         msg_datetime = pubsub_msg.publish_time
-        # need a non-TZ-aware object in UTC
-        cur_datetime = datetime.datetime.utcnow()
+        # need a TZ-aware object in UTC
+        cur_datetime = datetime.datetime.now(datetime.timezone.utc)
         msg_age = (cur_datetime - msg_datetime).total_seconds()
         if msg_age > self._max_msg_age:
             msg_logger.warn(f'Message is too old ({msg_age} seconds), '


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
https://github.com/spotify/gordon-gcp/blob/develop/src/gordon_gcp/plugins/service/event_consumer.py#L318 breaks because one object is TZ-aware and one is naive.  I thought the pubsub one was naive when I wrote it, but apparently not.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed timezone bug in consumer.
```
