### PR TITLE
Add additional octet test cases for get_managed_zone

### DIFF
--- a/src/gordon_gcp/clients/gdns.py
+++ b/src/gordon_gcp/clients/gdns.py
@@ -127,11 +127,13 @@ class GDNSClient(http.AIOConnection):
         managed zone name which removes the trailing dot and replaces
         other dots with dashes, and in the case of reverse records,
         uses only the two most significant octets, prepended with
-        'reverse'.
+        'reverse'. At least two octets are required for reverse DNS zones.
 
         Example:
            get_managed_zone('example.com.') = 'example-com'
+           get_managed_zone('20.10.in-addr.arpa.) = 'reverse-20-10'
            get_managed_zone('30.20.10.in-addr.arpa.) = 'reverse-20-10'
+           get_managed_zone('40.30.20.10.in-addr.arpa.) = 'reverse-20-10'
 
         Args:
             zone (str): DNS zone.

--- a/tests/unit/clients/test_gdns.py
+++ b/tests/unit/clients/test_gdns.py
@@ -150,7 +150,9 @@ async def test_get_records_for_zone(fake_response_data, client, caplog,
 
 @pytest.mark.parametrize('dns_zone,exp_managed_zone', [
     ('example.com.', 'example-com'),
-    ('30.20.10.in-addr.arpa.', 'reverse-20-10')
+    ('20.10.in-addr.arpa.', 'reverse-20-10'),
+    ('30.20.10.in-addr.arpa.', 'reverse-20-10'),
+    ('40.30.20.10.in-addr.arpa.', 'reverse-20-10')
 ])
 def test_get_managed_zone(dns_zone, exp_managed_zone, client):
     assert exp_managed_zone == client.get_managed_zone(dns_zone)


### PR DESCRIPTION
- Add examples to method docstring
- This makes it more clear that the get_managed_zone can handle reverse zones with numbers of octets other than just 2