### PR TITLE
Lower minimum TTL in event schema to match reality

### DIFF
--- a/src/gordon_gcp/schema/schemas/event.schema.json
+++ b/src/gordon_gcp/schema/schemas/event.schema.json
@@ -49,7 +49,7 @@
                     "description": "TTL in seconds; default 300 seconds",
                     "type": "number",
                     "maximum": 86400,
-                    "minimum": 300,
+                    "minimum": 60,
                     "default": 300
                 },
                 "type": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
We have DNS records with TTLs below 300 which were being dropped by this schema.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Lower minimum TTL for event schema to 60
```
