### PR TITLE
Revert TERMINATED filter in code

### DIFF
--- a/src/gordon_gcp/plugins/janitor/authority.py
+++ b/src/gordon_gcp/plugins/janitor/authority.py
@@ -174,15 +174,8 @@ class GCEAuthority:
             coros.add(coro)
 
         all_results = await asyncio.gather(*coros, return_exceptions=True)
-        all_results = self._filter_results(all_results)
 
-        instances = []
-        for instance in all_results:
-            if instance['status'] == 'TERMINATED':
-                logging.info(f'Skipping terminated instance: "{instance}"')
-                continue
-            instances.append(instance)
-        return instances
+        return self._filter_results(all_results)
 
     def _create_instance_rrset(self, instance):
         ip = instance['networkInterfaces'][0]['accessConfigs'][0]['natIP']

--- a/tests/unit/plugins/janitor/test_authority.py
+++ b/tests/unit/plugins/janitor/test_authority.py
@@ -102,12 +102,10 @@ async def test_run_publishes_msg_to_channel(mocker, authority_config,
                                             get_gce_client, create_mock_coro,
                                             instance_data, metrics):
     instances = []
-    for i in range(1, 5):
+    for i in range(1, 4):
         inst = copy.deepcopy(instance_data)
         inst['name'] = f'host-{i}'
         inst['networkInterfaces'][0]['accessConfigs'][0]['natIp'] = f'1.1.1.{i}'
-        if i == 4:
-            inst['status'] = 'TERMINATED'
         instances.append(inst)
 
     active_projects_mock, active_projects_coro = create_mock_coro()
@@ -128,8 +126,6 @@ async def test_run_publishes_msg_to_channel(mocker, authority_config,
 
     _expected_rrsets = []
     for instance in instances:
-        if instance['status'] == 'TERMINATED':
-            continue
         ip = instance['networkInterfaces'][0]['accessConfigs'][0]['natIP']
         _expected_rrsets.append({
             'name': f"{instance['name']}.{authority_config['dns_zone']}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
Reverts https://github.com/spotify/gordon-gcp/pull/94.  Moving the filter to code didn't prevent the timeouts we were seeing, so putting it back in config where it really belongs.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Revert TERMINATED filter in authority.
```
