### PR TITLE
[reconciler] remove attrs and use sets for comparison

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 aiohttp==2.3.9
 asyncio-extras==1.3.0
-attrs==17.4.0
 google-api-core==1.6.0
 google-auth==1.3.0
 google-cloud-pubsub==0.39.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
This PR contains a fix for the reconciler bug accidentally merged in with https://github.com/spotify/gordon-gcp/pull/106

There are three main components to the PR
1. Adjust `test_reconciler.validate_rrsets_by_zone` to actually fail based off the previous PR.
2. Drop use of `attrs` for `reconciler.ResourceRecordSet` in favor of a simple object where we control which attributes are used for comparison. It adds a few more lines of boilerplate code, but I feel it's easier to understand and control.
3. Simplify the reconciliation logic to remove extra list iterations and use sets instead.

Within those three changes there are some subtler changes. 
- Use tuple internally in `reconciler.ResourceRecordSet.rrdatas` and update the docstring to indicate rrdatas should be a iterables of strings (not possibly unhashable objects). This should be fine as tuple also json serializes as an array ([adjusted a test in publisher](https://github.com/spotify/gordon-gcp/pull/108/files#diff-2cdc114177c7a5745a4de1e484e0a9dbR85) to illustrate) and string is consistent with the Google Cloud DNS API (https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets#resource) and needed to avoid unnecessary complexity for hashing.  
- No longer drop conflicting deletes. Previously if a record of same name and type were to be added and deleted from a zone, we would drop the deletion, because the gdns publisher in Gordon has some logic for deleting conflicting records. I think this was done to save sending an unnecessary pubsub message. However it should be relatively infrequent (say IP reuse) and adds complexity to the reconciliation process. Instead I have chosen to send the deletions first, so we can be sure that the deletion happens before the addition.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes # https://github.com/spotify/gordon-gcp/pull/106

**Special notes for your reviewer**:
@spotify/alf 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix reconciler bug introduced in v0.0.1.dev30.
```
