### PR TITLE
Fallback to default token URI if not set

### DIFF
--- a/src/gordon_gcp/clients/_utils.py
+++ b/src/gordon_gcp/clients/_utils.py
@@ -24,6 +24,7 @@ DEFAULT_REQUEST_HEADERS = {
     'Accept-Encoding': 'gzip',
     'User-Agent': 'custom-aiohttp-gcloud-python',
 }
+DEFAULT_TOKEN_URI = "https://www.googleapis.com/oauth2/v4/token"
 
 # aiohttp does not log client request/responses; mimicking
 # `requests` log format

--- a/src/gordon_gcp/clients/auth.py
+++ b/src/gordon_gcp/clients/auth.py
@@ -141,7 +141,10 @@ class GAuthClient:
         return session
 
     def _setup_token_request(self):
-        url = self.creds._token_uri
+        if hasattr(self.creds, '_token_uri'):
+            url = self.creds._token_uri
+        else:
+            url = _utils.DEFAULT_TOKEN_URI
 
         headers = _utils.DEFAULT_REQUEST_HEADERS.copy()
         headers.update(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

When using default compute engine credentials (i.e. default application credentials on GCE / GKE) the object won't contain a  `_token_uri` attribute. This PR provides a fallback to use the default token uri as defined here: https://github.com/googleapis/google-auth-library-python/blob/master/google/auth/compute_engine/credentials.py#L120

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note

```
