### PR TITLE
Refresh function

### DIFF
--- a/src/gordon_gcp/clients/_utils.py
+++ b/src/gordon_gcp/clients/_utils.py
@@ -24,7 +24,6 @@ DEFAULT_REQUEST_HEADERS = {
     'Accept-Encoding': 'gzip',
     'User-Agent': 'custom-aiohttp-gcloud-python',
 }
-DEFAULT_TOKEN_URI = "https://www.googleapis.com/oauth2/v4/token"
 
 # aiohttp does not log client request/responses; mimicking
 # `requests` log format


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
Follow up from: https://github.com/spotify/gordon-gcp/pull/116 
This change adds support for compute engine credentials while still keeping the http calls async. To get a refresh token from compute engine credentials a GET request to the metadata server needs to be made rather than a POST to the token one.