### PR TITLE
Ensure to use correct email when calling token url

### DIFF
--- a/src/gordon_gcp/clients/auth.py
+++ b/src/gordon_gcp/clients/auth.py
@@ -198,9 +198,10 @@ class GAuthClient:
                   '?recursive=true')
 
         sa_response = await self._execute_request(sa_url, 'GET', headers)
-        email = (sa_response['email']
-                 if 'email' in sa_response
-                 else self.creds._service_account_email)
+        if 'email' in sa_response:
+            email = sa_response['email']
+        else:
+            email = self.creds._service_account_email
 
         token_url = (f'http://{metadata_host}/computeMetadata/'
                      'v1/instance/service-accounts/'
@@ -240,9 +241,9 @@ class GAuthClient:
             return await resp.json()
 
     def _handle_refresh_token_response(self, response):
-        try:
+        if 'access_token' in response:
             self.token = response['access_token']
-        except KeyError:
+        else:
             msg = '[{request_id}] No access token in response.'
             logging.error(msg)
             raise exceptions.GCPAuthError(msg)

--- a/tests/unit/clients/test_auth.py
+++ b/tests/unit/clients/test_auth.py
@@ -278,14 +278,18 @@ async def test_refresh_token_with_compute_engine_cred(
         client_with_compute_engine_cred, mock_parse_expiry,
         caplog, payload_resp_refresh_token):
     """Successfully refresh access token with compute engine credentials ."""
-    url = ('http://metadata.google.internal/'
-           'computeMetadata/v1/instance/service-accounts/default/token')
+    sa_url = ('http://metadata.google.internal/'
+              'computeMetadata/v1/instance/service-accounts/default/'
+              '?recursive=true')
+    token_url = ('http://metadata.google.internal/'
+                 'computeMetadata/v1/instance/service-accounts/default/token')
     token = 'c0ffe3'
     with aioresponses() as mocked:
-        mocked.get(url, status=200, payload=payload_resp_refresh_token)
+        mocked.get(sa_url, status=200, payload={'email': 'default'})
+        mocked.get(token_url, status=200, payload=payload_resp_refresh_token)
         await client_with_compute_engine_cred.refresh_token()
     assert token == client_with_compute_engine_cred.token
-    assert 2 == len(caplog.records)
+    assert 4 == len(caplog.records)
 
 
 args = 'status,payload,exc,err_msg'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
This will make another call to the metadata API when using compute engine credentials to first ensure to get the correct email. Then this email is used to get a new access token. Previously this was not done causing the call to be made using `default` as the email, which the metadata server might reject and return a 403.
